### PR TITLE
feat: Sprint 2 - decks & cards (dominio core)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 Todas as alterações relevantes do projeto são registradas aqui, conforme `<regra_obrigatoria id="changelog">` em [PROMPT_REFINADO.md](./PROMPT_REFINADO.md).
 
+## [Sprint 2] Decks & Cards (domínio core) — 2026-08-10
+
+Primeira feature real sobre o domínio de deck/card migrado na Sprint 0, agora multi-tenant e com repetição espaçada. Ver `openspec/changes/sprint-2-decks-cards/`.
+
+### Adicionado
+- Isolamento multi-tenant em MongoDB: `owner_id` obrigatório em toda assinatura de método de repositório (`Deck`/`Category`/`Card`/`CardReview`), embutido diretamente no filtro da query — mecanismo próprio da camada Motor, já que o `TenantOwnedModel` da Sprint 1 é ORM/Postgres-only.
+- Entidade `Category` (nova — não existia no domínio migrado); `Deck` ganhou `category_id`, `Card` ganhou `tags` e os campos de agendamento FSRS (`stability`, `difficulty`, `due_at`, `fsrs_state`).
+- Repetição espaçada via FSRS (pacote `fsrs`, o mesmo algoritmo do Anki real desde 2023) — `domain/services/scheduling_service.py`.
+- Entidade `CardReview` — um documento por evento de revisão (mesma granularidade do `revlog` do Anki), deliberadamente distinta de `GenerationSession` (que continua representando só o job de geração de cards via IA).
+- Endpoints REST versionados (`/api/v1/decks/`, `/categories/`, `/cards/`, `/cards/{id}/review/`) via Generic Views do DRF sobre repositório Motor — serializers `serializers.Serializer` manuais (não `ModelSerializer`), `get_queryset()` retornando lista já resolvida via `async_to_sync`; `APIView` dedicada para a ação de revisão (não é CRUD).
+- Índices Mongo por `owner_id`/`deck_id`/`category_id`/`tags`/`due_at`, definidos em `IndexDefinitions` (`schemas.py`) — agora fonte única também para `MongoDBConnectionManager.create_indexes()` (antes havia uma segunda lista hardcoded e divergente).
+- Comando de seed multi-tenant (`seed_decks`): múltiplos usuários, decks/categorias/cards com tags, `CardReview` com datas passadas/recentes/futuras — entrypoint `asyncio.run` com `asyncio.gather` para inserções concorrentes reais (sem bridge `async_to_sync`), protegido contra produção (`settings.DEBUG`), suporte a `--reset`.
+- 16 novos testes automatizados (isolamento cross-tenant contra Mongo real, CRUD dos endpoints, revisão/agendamento FSRS, cards devidos, guarda de produção do seed) — **28/28 passando** com a Sprint 1.
+- Hierarquia de exceções própria do projeto (`core/exceptions.py`): `AppError`, base abstrata (não instanciável diretamente — nem `ABC` sozinho bloqueia isso em subclasses de `Exception`, foi preciso um guard manual). Duas ramificações: `DomainValidationError` (substitui todo `ValueError` cru levantado por entidades/objetos de valor) e `InfrastructureError` → `RepositoryError`/`CardNotFoundError`/`DeckNotFoundError`/`CategoryNotFoundError`/`SessionNotFoundError`/`MongoNotConnectedError`/`MongoConfigError` (substitui os `RuntimeError`/`ValueError` da camada Mongo). Consolidado em `apps/decks/infrastructure/exceptions.py`, corrigindo de passagem um layering estranho: `RepositoryError` vivia dentro de `card_repository.py` e todo outro repositório importava dela como se fosse módulo compartilhado.
+
+### Corrigido
+- **Bug real de produção, descoberto via verificação end-to-end com requests HTTP reais (não só testes unitários)**: `AsyncIOMotorClient` fica preso ao event loop em que foi criado; `asgiref.sync.async_to_sync` cria um event loop novo a cada chamada bridged, sem loop "principal" já rodando na thread. O singleton `MongoDBConnectionManager` e o cache de `_collection` por instância de repositório quebravam com `RuntimeError: Event loop is closed` já na segunda/terceira chamada do processo. Corrigido: `is_connected()` agora valida o loop atual e força reconexão quando diverge; repositórios pararam de cachear `_collection` na instância.
+- `GenerationSessionRepository.find_by_id()` (Sprint 0) chamava `CardRepository.find_by_deck_id()` sem `owner_id` — quebrado pela mudança acima; `owner_id` agora é parâmetro explícito também nesse método.
+- **Segundo bug real, também de produção, encontrado em revisão pré-commit**: `datetime.utcnow()` (deprecated) foi trocado por `datetime.now(timezone.utc)` em todo `apps/decks/` — mas o mais importante foi o que essa troca revelou: Motor/pymongo devolvem datetime *naive* na leitura (mesmo quando o valor foi inserido como aware), então revisar o mesmo card uma segunda vez (com `due_at`/`last_reviewed_at` vindos do Mongo) quebrava com `TypeError: can't subtract offset-naive and offset-aware datetimes` dentro do `fsrs.Scheduler`. Corrigido na fronteira `schemas.py`: novo helper `datetime_from_mongo()` reanexa o offset UTC em toda leitura, usado nos cinco schemas. Validado revisando o mesmo card 3x seguidas via API real.
+
+### Qualidade de código (revisão pré-commit)
+- Espaço em branco no fim de linha removido de 16 arquivos em `apps/decks/` (domínio + infraestrutura, código herdado da Sprint 0 nunca revisado antes).
+- `seed_decks.py` reescrito para legibilidade: os `asyncio.gather(*( ... for ... ))` aninhados de 3 níveis viraram "monta a lista de objetos" → "salva tudo concorrentemente" como dois passos nomeados e separados, sem custo de performance; números mágicos (`2` decks por categoria, `4` cards por deck) viraram constantes nomeadas.
+
+### Decisão de escopo
+- Métodos/serviços legados do protótipo antigo de geração de vocabulário (`find_by_word`, `find_similar_cards`, `find_duplicates`, `exists_by_word`, `duplicate_detection_service`, `card_quality_service`) — não usados por nenhuma view/URL, não previstos no PRD — foram mantidos e escopados por `owner_id`, por decisão explícita do usuário, para o caso do agente de IA (Sprint 5) reaproveitar essa lógica.
+
 ## [Sprint 1] Autenticação & Multi-tenant — 2026-08-05
 
 Primeira feature real do sistema, sobre a fundação da Sprint 0. Ver `openspec/changes/sprint-1-autenticacao-multi-tenant/`.

--- a/PRD.md
+++ b/PRD.md
@@ -114,13 +114,15 @@ Todas em `<decisoes_resolvidas>` de `PROMPT_REFINADO.md`. Resumo rápido:
 
 **Objetivo**: a funcionalidade central do produto — sem isso, nada mais tem dado real para trabalhar em cima.
 
-- [ ] 2.1 Endpoints versionados (`/api/v1/`) de CRUD para decks, categorias e cards (Generic Views do DRF)
-- [ ] 2.2 Lógica de repetição espaçada como base do fluxo de estudo
-- [ ] 2.3 Registro de sessões de estudo (acertos/erros, timestamps) para alimentar estatísticas futuras
-- [ ] 2.4 Índices obrigatórios: deck, categoria, tag de relacionamento deck/card
-- [ ] 2.5 Serializers magros, herdáveis, sem boilerplate desnecessário
-- [ ] 2.6 Django management command de seed: múltiplos usuários/tenants, decks/categorias variadas, cards com históricos de acerto/erro, datas passadas/recentes/futuras — protegido contra execução em produção, idempotente ou com `--reset`
-- [ ] 2.7 Testar comando de seed e a proteção contra produção explicitamente
+- [x] 2.1 Endpoints versionados (`/api/v1/`) de CRUD para decks, categorias e cards (Generic Views do DRF) — `apps/decks/views.py`/`urls.py`; `Category` é entidade nova (não existia no domínio migrado)
+- [x] 2.2 Lógica de repetição espaçada como base do fluxo de estudo — FSRS via pacote `fsrs` (`domain/services/scheduling_service.py`), não SM-2 manual
+- [x] 2.3 Registro de sessões de estudo (acertos/erros, timestamps) para alimentar estatísticas futuras — entidade `CardReview` (um evento por revisão, não uma "sessão" agregada — mesma granularidade do `revlog` do Anki; deliberadamente distinta de `GenerationSession`)
+- [x] 2.4 Índices obrigatórios: deck, categoria, tag de relacionamento deck/card — `IndexDefinitions` em `schemas.py`, agora fonte única também para `MongoDBConnectionManager.create_indexes()`
+- [x] 2.5 Serializers magros, herdáveis, sem boilerplate desnecessário — `serializers.Serializer` manuais (não `ModelSerializer`, que exige Model Django real)
+- [x] 2.6 Django management command de seed: múltiplos usuários/tenants, decks/categorias variadas, cards com históricos de acerto/erro, datas passadas/recentes/futuras — protegido contra execução em produção, idempotente ou com `--reset` — `seed_decks` (validado rodando de verdade contra Mongo/Postgres reais)
+- [x] 2.7 Testar comando de seed e a proteção contra produção explicitamente — `test_seed_command.py`; **28/28 testes passando** (Sprint 1 + 2)
+
+**Nota de implementação**: isolamento multi-tenant em MongoDB precisou de mecanismo próprio (não o `TenantOwnedModel` da Sprint 1, que é ORM/Postgres-only) — `owner_id` obrigatório em toda assinatura de método de repositório. Um bug real de produção foi descoberto e corrigido durante a verificação end-to-end via HTTP: `AsyncIOMotorClient` ficava preso ao event loop em que era criado, e `async_to_sync` cria um loop novo a cada chamada — quebrava a partir da segunda/terceira chamada bridged do processo (ver Risks em `openspec/changes/sprint-2-decks-cards/design.md`).
 
 *Critérios de aceite relevantes: 11.*
 

--- a/PROMPT_REFINADO.md
+++ b/PROMPT_REFINADO.md
@@ -426,6 +426,22 @@ Ordem de implementação dos microsserviços FastAPI: geração de documentos (r
 Cada unidade implantável vive em pasta própria na raiz: `django/` (backend principal, antes espalhado solto na raiz), `microservices/<nome>/` (renomeado de `services/`, para não colidir com o termo já usado em `apps/decks/domain/services/`), `frontend/` (placeholder da Sprint 3). `docker-compose.yml`/`Makefile` continuam na raiz, orquestrando todas as pastas.
 </decisao_resolvida>
 
+<decisao_resolvida id="isolamento-multi-tenant-mongo">
+Sprint 2: isolamento multi-tenant em MongoDB (decks/cards/categorias/card_reviews) é implementado via `owner_id` obrigatório embutido diretamente em toda query do repositório (nunca checado depois em Python) — mecanismo próprio da camada de repositório Motor, já que não há `Manager`/`QuerySet` do Django ORM para essas coleções (o `TenantOwnedModel` da Sprint 1 é ORM/Postgres-only e não se aplica aqui). Ver D1 em `openspec/changes/sprint-2-decks-cards/design.md`.
+</decisao_resolvida>
+
+<decisao_resolvida id="generic-views-sobre-mongo">
+Generic Views do DRF continuam a forma preferencial de expor CRUD, mesmo sobre dado não-ORM: serializers são `serializers.Serializer` manuais (nunca `ModelSerializer`) com `create()`/`update()` delegando ao repositório, e `get_queryset()` devolve uma lista Python já resolvida (a paginação do DRF só exige algo fatiável/contável, não um `QuerySet` real). `APIView` fica reservado para ações que não são CRUD (ex.: registrar revisão de card). Ver D2 em design.md da Sprint 2.
+</decisao_resolvida>
+
+<decisao_resolvida id="sync-views-async-repositorio">
+Views do Django/DRF permanecem síncronas (não se adota `adrf`/views assíncronas nativas nesta fase) — chamam os repositórios Motor via `asgiref.sync.async_to_sync`. Os repositórios continuam em Motor (não migram para `pymongo`), porque já existe um segundo consumidor real que se beneficia de concorrência de verdade sem bridge (o comando de seed, via `asyncio.gather`). Ver D3/D3.1 em design.md da Sprint 2 — inclui um risco real descoberto em implementação (event loop preso no client Mongo) e sua correção, documentado ali.
+</decisao_resolvida>
+
+<decisao_resolvida id="repeticao-espacada-fsrs">
+Algoritmo de repetição espaçada: FSRS via o pacote Python `fsrs` (o mesmo que o Anki real usa desde 2023) — não SM-2 implementado manualmente. Registro de revisão é uma entidade própria, `CardReview` (um documento por evento de revisão, mesma granularidade do `revlog` do Anki), deliberadamente distinta de `GenerationSession` (que continua representando só o job de geração de cards via IA). Ver D4/D5 em design.md da Sprint 2.
+</decisao_resolvida>
+
 </decisoes_resolvidas>
 
 <criterios_de_aceite>
@@ -481,6 +497,10 @@ Levantamento de gaps de arquitetura conduzido via `/opsx:propose` em `openspec/c
 - [x] **Orquestração de containers na VPS**: Docker Compose direto — Kubernetes desacoplado como projeto de estudo separado (usuário sem experiência prévia; ver `<ponto_critico id="idempotencia-revisao">` para outro item levantado na mesma conversa).
 - [x] **Taxa de rate limiting**: 3 requests/segundo.
 - [x] **Estrutura do monorepo**: `django/` + `microservices/<nome>/` + `frontend/`, uma pasta por unidade implantável — ver `<estrutura_monorepo>`.
+- [x] **Isolamento multi-tenant em MongoDB** (Sprint 2): `owner_id` obrigatório embutido em toda query do repositório — ver `isolamento-multi-tenant-mongo`.
+- [x] **Generic Views sobre dado não-ORM** (Sprint 2): serializers manuais + `get_queryset()` retornando lista resolvida — ver `generic-views-sobre-mongo`.
+- [x] **Sync vs. async nas views de deck/card** (Sprint 2): views síncronas + `async_to_sync`, repositórios continuam em Motor — ver `sync-views-async-repositorio`.
+- [x] **Algoritmo de repetição espaçada** (Sprint 2): FSRS via pacote `fsrs`, não SM-2 manual — ver `repeticao-espacada-fsrs`.
 
 ### Itens que ainda dependem de decisão explícita do usuário
 

--- a/README.md
+++ b/README.md
@@ -19,25 +19,56 @@ Este README é só uma porta de entrada. As fontes de verdade do projeto são:
 
 ## 🏗️ Arquitetura
 
-```
-Cliente (SPA React, hospedada em S3)
-        │  REST /api/v1/...
-        ▼
-Django + DRF (django/core/ + django/apps/)  ──▶  PostgreSQL (auth/Permission/Group)
-        │                                   ──▶  MongoDB (decks/cards/estatísticas)
-        │  Celery (RabbitMQ broker, Redis result backend)
-        ▼
-Microsserviços FastAPI (microservices/)
-  ├─ document-generator  (relatórios PDF, exportação .apkg — já implementado)
-  ├─ ai-agent            (LangChain/LangGraph — Sprint 5)
-  └─ whatsapp-evolution   (Evolution API — Sprint 6)
+```mermaid
+flowchart TB
+    subgraph Client["Cliente"]
+        SPA["SPA React (S3) — Sprint 3"]
+    end
+
+    subgraph DjangoApp["Django + DRF (django/)"]
+        Auth["apps.accounts\nJWT + Google OAuth\nTenantOwnedModel (ORM)"]
+        Decks["apps.decks\nDeck / Category / Card / CardReview\nGeneric Views + APIView pontual"]
+        Bridge["async_to_sync\n(view sync → repositório Motor)"]
+    end
+
+    subgraph Repos["Repositórios Motor (async)"]
+        DeckRepo["DeckRepository"]
+        CardRepo["CardRepository\n+ owner_id obrigatório"]
+        CategoryRepo["CategoryRepository"]
+        ReviewRepo["CardReviewRepository"]
+        GenRepo["GenerationSessionRepository\n(protótipo antigo — inalterado)"]
+    end
+
+    subgraph Seed["management command seed"]
+        SeedCmd["asyncio.gather\n(concorrência real, sem bridge)"]
+    end
+
+    subgraph Data["Bancos"]
+        PG[("PostgreSQL\nauth / Permission / Group")]
+        Mongo[("MongoDB\ndecks / cards / categories\ncard_reviews / generation_sessions")]
+        Redis[("Redis\ncache / JWT blocklist / throttle")]
+    end
+
+    subgraph Micro["Microsserviços FastAPI (microservices/)"]
+        DocGen["document-generator\n.apkg + PDF — Sprint 4"]
+    end
+
+    SPA -->|"REST /api/v1/..."| Auth
+    SPA -->|"REST /api/v1/..."| Decks
+    Auth --> PG
+    Auth --> Redis
+    Decks --> Bridge
+    Bridge --> DeckRepo & CardRepo & CategoryRepo & ReviewRepo
+    DeckRepo & CardRepo & CategoryRepo & ReviewRepo & GenRepo --> Mongo
+    SeedCmd --> DeckRepo & CardRepo & CategoryRepo & ReviewRepo
+    DjangoApp -.->|"chamada HTTP versionada — Sprint 4"| DocGen
 ```
 
 Estrutura de pastas: cada unidade implantável é uma pasta própria na raiz — `django/` (o backend principal), `microservices/<nome>/` (cada microsserviço FastAPI, um por pasta) e `frontend/` (SPA React, Sprint 3). `docker-compose.yml` e `Makefile` ficam na raiz e orquestram todas elas.
 
 - **Backend principal**: Django + DRF, multi-tenant, URLs versionadas (`/api/v1/`).
 - **Autenticação**: JWT (`simplejwt`) com refresh token revogável via blocklist no Redis + login Google OAuth (`django-allauth` + `dj-rest-auth`) — `django/apps/accounts/`. Multi-tenant = isolamento por usuário (`TenantOwnedModel`), sem entidade `Organization` separada.
-- **Domínio de deck/card**: `django/apps/decks/` — entities, value objects e repositórios Mongo (via Motor), consolidados a partir do protótipo anterior.
+- **Domínio de deck/card**: `django/apps/decks/` — entities (`Deck`/`Category`/`Card`/`CardReview`), value objects e repositórios Mongo (via Motor). Isolamento multi-tenant aqui é `owner_id` obrigatório embutido em toda query do repositório (mecanismo próprio, já que não há ORM do Django sobre Mongo). CRUD via Generic Views do DRF com serializers manuais; repetição espaçada via FSRS (pacote `fsrs`); views síncronas fazendo bridge (`async_to_sync`) para os repositórios assíncronos.
 - **Microsserviço de documentos**: `microservices/document-generator/` — FastAPI, gera `.apkg` (genanki + gTTS) e relatórios PDF.
 - **Mensageria**: RabbitMQ (broker do Celery) + Redis (result backend/cache).
 - **Deploy real**: VPS (Docker Compose) — não AWS. O único uso de AWS é o bucket S3 do frontend estático.
@@ -49,10 +80,11 @@ Estrutura de pastas: cada unidade implantável é uma pasta própria na raiz —
 |---|---|
 | Backend principal | Django 6 + Django REST Framework, Python 3.13, Poetry |
 | Autenticação | JWT (`djangorestframework-simplejwt`) + Google OAuth (`django-allauth` + `dj-rest-auth`) |
+| Repetição espaçada | FSRS (pacote `fsrs`) |
 | Testes | pytest + pytest-django |
 | Microsserviços | FastAPI, `venv`/`requirements.txt` por serviço |
 | Banco relacional | PostgreSQL (auth/permissions do Django) |
-| Banco de domínio | MongoDB (decks/cards/estatísticas), via Motor |
+| Banco de domínio | MongoDB (decks/cards/categorias/reviews), via Motor |
 | Fila/assíncrono | Celery + RabbitMQ + Redis |
 | Frontend | React (SPA estática, hospedada em S3) |
 | Deploy | Docker Compose numa VPS |
@@ -111,11 +143,16 @@ Estrutura de pastas: cada unidade implantável é uma pasta própria na raiz —
 ## 🧪 Testes
 
 ```bash
-# Suíte pytest (auth, multi-tenant, auditoria, rate limiting — 12 testes, requer Postgres + Redis rodando)
-poetry -C django run pytest apps/accounts
+# Suíte pytest completa — 28 testes: auth/multi-tenant/auditoria/rate limiting (Sprint 1)
+# + isolamento multi-tenant Mongo/CRUD/revisão FSRS/seed (Sprint 2)
+# Requer Postgres + Redis + MongoDB rodando (`make up`)
+poetry -C django run pytest apps/accounts apps/decks
 
-# Teste de integração MongoDB (script standalone, requer `make up` rodando, ao menos o serviço mongo)
+# Teste de integração MongoDB (script standalone, à parte do pytest — requer `make up` rodando, ao menos o serviço mongo)
 poetry -C django run python -m apps.decks.tests.test_mongodb_integration
+
+# Popular o banco com dados de desenvolvimento (múltiplos usuários/decks/categorias/cards/reviews)
+poetry -C django run python manage.py seed_decks        # --reset para recriar do zero
 ```
 
 ## 🎯 Roadmap
@@ -124,7 +161,7 @@ Roadmap completo, em sprints, com checklist detalhado: **[PRD.md](./PRD.md)**.
 
 - [x] Sprint 0 — Fundação de arquitetura (Django + domínio consolidado + Docker Compose + microsserviço de documentos)
 - [x] Sprint 1 — Autenticação & multi-tenant
-- [ ] Sprint 2 — Decks & Cards (domínio core)
+- [x] Sprint 2 — Decks & Cards (domínio core)
 - [ ] Sprint 3 — Frontend base & home dashboard
 - [ ] Sprint 4 — Exportação Anki & microsserviço de documentos (integração completa)
 - [ ] Sprint 5 — Agente de IA (LangChain/LangGraph)

--- a/django/apps/decks/domain/__init__.py
+++ b/django/apps/decks/domain/__init__.py
@@ -18,9 +18,9 @@ __all__ = [
     # Entidades
     'Card',
     'Deck',
-    'GenerationSession', 
+    'GenerationSession',
     'GenerationStatus',
-    
+
     # Value Objects
     'Word',
     'Translation',

--- a/django/apps/decks/domain/entities/__init__.py
+++ b/django/apps/decks/domain/entities/__init__.py
@@ -13,11 +13,15 @@ Características das Entidades:
 
 from .card import Card
 from .deck import Deck
+from .category import Category
+from .card_review import CardReview
 from .generation_session import GenerationSession, GenerationStatus
 
 __all__ = [
     'Card',
-    'Deck', 
+    'Deck',
+    'Category',
+    'CardReview',
     'GenerationSession',
     'GenerationStatus'
 ]

--- a/django/apps/decks/domain/entities/card.py
+++ b/django/apps/decks/domain/entities/card.py
@@ -12,7 +12,7 @@ Características da entidade Card:
 """
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, List
 from dataclasses import dataclass, field
 
@@ -20,143 +20,166 @@ from ..value_objects.word import Word
 from ..value_objects.translation import Translation
 from ..value_objects.example import Example
 from ..value_objects.audio_path import AudioPath
+from ..exceptions import DomainValidationError
 
 
 @dataclass
 class Card:
     """
     Entidade Card representa um card individual do Anki.
-    
+
     Atributos:
     - word: Objeto de valor Word (palavra em inglês)
     - translation: Objeto de valor Translation (tradução em português)
     - example: Objeto de valor Example (frase de exemplo)
+    - owner_id: dono do card (isolamento multi-tenant — ver D1 em
+      openspec/changes/sprint-2-decks-cards/design.md)
     - id: Identificador único (UUID)
     - audio_path: Caminho para arquivo de áudio (opcional)
     - context: Contexto que gerou este card
     - deck_id: ID do deck ao qual pertence
+    - tags: tags livres para categorização/índice (ver PRD Sprint 2, 2.4)
+    - stability/difficulty/due_at/fsrs_state/fsrs_step: campos de agendamento
+      FSRS (ver D4 em design.md) — nunca calculados aqui, só persistidos;
+      quem calcula é `domain/services/scheduling_service.py`
     - created_at: Data de criação
     - updated_at: Data da última atualização
     """
-    
+
     # Objetos de valor que compõem o card (obrigatórios)
     word: Word
     translation: Translation
     example: Example
-    
+    owner_id: str
+
     # Identidade única da entidade
     id: uuid.UUID = field(default_factory=uuid.uuid4)
-    
+
     # Campos opcionais
     audio_path: Optional[AudioPath] = None
-    
+
     # Metadados
     context: str = ""
     deck_id: Optional[uuid.UUID] = None
-    created_at: datetime = field(default_factory=datetime.utcnow)
-    updated_at: datetime = field(default_factory=datetime.utcnow)
-    
+    tags: List[str] = field(default_factory=list)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    # Agendamento de repetição espaçada (FSRS). fsrs_state usa os mesmos
+    # valores do enum `fsrs.State` (1=Learning, 2=Review, 3=Relearning) sem
+    # importar o pacote aqui, para o domínio não depender do algoritmo escolhido.
+    fsrs_state: int = 1
+    fsrs_step: Optional[int] = 0
+    stability: Optional[float] = None
+    difficulty: Optional[float] = None
+    due_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    last_reviewed_at: Optional[datetime] = None
+
     def __post_init__(self):
         """
         Validações que são executadas após a criação do objeto.
         Em DDD, as entidades devem sempre estar em estado válido.
         """
         self._validate_card()
-    
+
     def _validate_card(self) -> None:
         """
         Valida se o card está em estado válido.
-        
+
         Regras de negócio:
         1. Word não pode estar vazia
         2. Translation não pode estar vazia
         3. Example deve ter pelo menos 10 caracteres
         4. Context não pode ser None (pode ser string vazia)
+        5. owner_id é obrigatório (isolamento multi-tenant)
         """
         if not self.word or not self.word.value.strip():
-            raise ValueError("Word cannot be empty")
-        
+            raise DomainValidationError("Word cannot be empty")
+
         if not self.translation or not self.translation.value.strip():
-            raise ValueError("Translation cannot be empty")
-        
+            raise DomainValidationError("Translation cannot be empty")
+
         if not self.example or len(self.example.original.strip()) < 10:
-            raise ValueError("Example must have at least 10 characters")
-        
+            raise DomainValidationError("Example must have at least 10 characters")
+
         if self.context is None:
             self.context = ""
-    
+
+        if not self.owner_id or not str(self.owner_id).strip():
+            raise DomainValidationError("owner_id cannot be empty")
+
     def add_audio(self, audio_path: AudioPath) -> None:
         """
         Adiciona áudio ao card.
-        
+
         Regra de negócio: Um card pode ter apenas um áudio.
         Se já existir, substitui o anterior.
         """
         self.audio_path = audio_path
-        self.updated_at = datetime.utcnow()
-    
+        self.updated_at = datetime.now(timezone.utc)
+
     def update_translation(self, new_translation: Translation) -> None:
         """
         Atualiza a tradução do card.
-        
+
         Regra de negócio: A tradução deve ser diferente da atual.
         """
         if new_translation.value.strip() == self.translation.value.strip():
-            raise ValueError("New translation must be different from current")
-        
+            raise DomainValidationError("New translation must be different from current")
+
         self.translation = new_translation
-        self.updated_at = datetime.utcnow()
-    
+        self.updated_at = datetime.now(timezone.utc)
+
     def update_example(self, new_example: Example) -> None:
         """
         Atualiza o exemplo do card.
-        
+
         Regra de negócio: O exemplo deve ter pelo menos 10 caracteres.
         """
         if len(new_example.original.strip()) < 10:
-            raise ValueError("Example must have at least 10 characters")
-        
+            raise DomainValidationError("Example must have at least 10 characters")
+
         self.example = new_example
-        self.updated_at = datetime.utcnow()
-    
+        self.updated_at = datetime.now(timezone.utc)
+
     def assign_to_deck(self, deck_id: uuid.UUID) -> None:
         """
         Associa o card a um deck específico.
-        
+
         Regra de negócio: Um card pode pertencer a apenas um deck.
         """
         self.deck_id = deck_id
-        self.updated_at = datetime.utcnow()
-    
+        self.updated_at = datetime.now(timezone.utc)
+
     def is_similar_to(self, other: 'Card', similarity_threshold: float = 0.8) -> bool:
         """
         Verifica se este card é similar a outro card.
-        
+
         Usado para detecção de duplicatas.
         Por enquanto, compara apenas as palavras, mas pode ser expandido
         para usar algoritmos de similaridade mais sofisticados.
-        
+
         Args:
             other: Outro card para comparação
             similarity_threshold: Limiar de similaridade (0.0 a 1.0)
-            
+
         Returns:
             True se os cards forem considerados similares
         """
         if not isinstance(other, Card):
             return False
-        
+
         # Comparação simples por enquanto
         # TODO: Implementar algoritmo de similaridade mais sofisticado
         word_similarity = self.word.value.lower().strip() == other.word.value.lower().strip()
         translation_similarity = self.translation.value.lower().strip() == other.translation.value.lower().strip()
-        
+
         return word_similarity and translation_similarity
-    
+
     def to_dict(self) -> dict:
         """
         Converte o card para dicionário.
-        
+
         Útil para serialização e persistência.
         """
         return {
@@ -164,39 +187,55 @@ class Card:
             "word": self.word.to_dict(),
             "translation": self.translation.to_dict(),
             "example": self.example.to_dict(),
+            "owner_id": self.owner_id,
             "audio_path": self.audio_path.to_dict() if self.audio_path else None,
             "context": self.context,
             "deck_id": str(self.deck_id) if self.deck_id else None,
+            "tags": list(self.tags),
+            "fsrs_state": self.fsrs_state,
+            "fsrs_step": self.fsrs_step,
+            "stability": self.stability,
+            "difficulty": self.difficulty,
+            "due_at": self.due_at.isoformat(),
+            "last_reviewed_at": self.last_reviewed_at.isoformat() if self.last_reviewed_at else None,
             "created_at": self.created_at.isoformat(),
             "updated_at": self.updated_at.isoformat()
         }
-    
+
     @classmethod
     def from_dict(cls, data: dict) -> 'Card':
         """
         Cria um card a partir de um dicionário.
-        
+
         Útil para desserialização e recuperação do banco.
         """
         from ..value_objects.word import Word
         from ..value_objects.translation import Translation
         from ..value_objects.example import Example
         from ..value_objects.audio_path import AudioPath
-        
+
         return cls(
             id=uuid.UUID(data["id"]),
             word=Word.from_dict(data["word"]),
             translation=Translation.from_dict(data["translation"]),
             example=Example.from_dict(data["example"]),
+            owner_id=data["owner_id"],
             audio_path=AudioPath.from_dict(data["audio_path"]) if data.get("audio_path") else None,
             context=data.get("context", ""),
+            tags=list(data.get("tags", [])),
+            fsrs_state=data.get("fsrs_state", 1),
+            fsrs_step=data.get("fsrs_step", 0),
+            stability=data.get("stability"),
+            difficulty=data.get("difficulty"),
+            due_at=datetime.fromisoformat(data["due_at"]) if data.get("due_at") else datetime.now(timezone.utc),
+            last_reviewed_at=datetime.fromisoformat(data["last_reviewed_at"]) if data.get("last_reviewed_at") else None,
             deck_id=uuid.UUID(data["deck_id"]) if data.get("deck_id") else None,
             created_at=datetime.fromisoformat(data["created_at"]),
             updated_at=datetime.fromisoformat(data["updated_at"])
         )
-    
+
     def __str__(self) -> str:
         return f"Card(id={self.id}, word='{self.word.value}', translation='{self.translation.value}')"
-    
+
     def __repr__(self) -> str:
         return f"Card(id={self.id}, word='{self.word.value}', translation='{self.translation.value}', deck_id={self.deck_id})"

--- a/django/apps/decks/domain/entities/card_review.py
+++ b/django/apps/decks/domain/entities/card_review.py
@@ -1,0 +1,83 @@
+"""
+Entidade CardReview - Um evento de revisão de um card (Sprint 2, PRD 2.3).
+
+Granularidade de um evento por revisão (não uma "sessão" agregada) — mesma
+granularidade que o Anki real usa internamente (tabela `revlog`). É uma
+entidade própria, deliberadamente distinta de `GenerationSession` (que
+representa um job de geração de cards via IA, do protótipo antigo, e
+continua inalterada). Ver D5 em
+openspec/changes/sprint-2-decks-cards/design.md.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+from dataclasses import dataclass, field
+from ..exceptions import DomainValidationError
+
+VALID_RATINGS = {"again", "hard", "good", "easy"}
+
+
+@dataclass
+class CardReview:
+    """
+    Entidade CardReview representa um único evento de revisão de um card,
+    junto com o resultado do agendamento FSRS após essa revisão.
+    """
+
+    card_id: uuid.UUID
+    owner_id: str
+    rating: str
+
+    id: uuid.UUID = field(default_factory=uuid.uuid4)
+    reviewed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    # Snapshot do agendamento do Card logo após esta revisão (ver
+    # domain/services/scheduling_service.py)
+    stability_after: Optional[float] = None
+    difficulty_after: Optional[float] = None
+    due_at_after: Optional[datetime] = None
+
+    def __post_init__(self):
+        self._validate_card_review()
+
+    def _validate_card_review(self) -> None:
+        if not self.owner_id or not str(self.owner_id).strip():
+            raise DomainValidationError("owner_id cannot be empty")
+
+        if self.card_id is None:
+            raise DomainValidationError("card_id cannot be None")
+
+        if self.rating not in VALID_RATINGS:
+            raise DomainValidationError(f"rating must be one of {sorted(VALID_RATINGS)}, got {self.rating!r}")
+
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "card_id": str(self.card_id),
+            "owner_id": self.owner_id,
+            "rating": self.rating,
+            "reviewed_at": self.reviewed_at.isoformat(),
+            "stability_after": self.stability_after,
+            "difficulty_after": self.difficulty_after,
+            "due_at_after": self.due_at_after.isoformat() if self.due_at_after else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "CardReview":
+        return cls(
+            id=uuid.UUID(data["id"]),
+            card_id=uuid.UUID(data["card_id"]),
+            owner_id=data["owner_id"],
+            rating=data["rating"],
+            reviewed_at=datetime.fromisoformat(data["reviewed_at"]),
+            stability_after=data.get("stability_after"),
+            difficulty_after=data.get("difficulty_after"),
+            due_at_after=datetime.fromisoformat(data["due_at_after"]) if data.get("due_at_after") else None,
+        )
+
+    def __str__(self) -> str:
+        return f"CardReview(card_id={self.card_id}, rating='{self.rating}')"
+
+    def __repr__(self) -> str:
+        return f"CardReview(id={self.id}, card_id={self.card_id}, rating='{self.rating}', reviewed_at={self.reviewed_at})"

--- a/django/apps/decks/domain/entities/category.py
+++ b/django/apps/decks/domain/entities/category.py
@@ -1,0 +1,72 @@
+"""
+Entidade Category - Agrupa decks por categoria (Sprint 2, ver PRD 2.4).
+
+Não existia no domínio migrado da Sprint 0 (protótipo antigo não tinha esse
+conceito) — criada do zero seguindo o mesmo padrão de `Deck`/`Card`
+(dataclass + owner_id obrigatório desde o primeiro campo, ver D6 em
+openspec/changes/sprint-2-decks-cards/design.md).
+"""
+
+import uuid
+from datetime import datetime, timezone
+from dataclasses import dataclass, field
+from ..exceptions import DomainValidationError
+
+
+@dataclass
+class Category:
+    """
+    Entidade Category representa uma categoria de organização de decks.
+    """
+
+    name: str
+    owner_id: str
+
+    id: uuid.UUID = field(default_factory=uuid.uuid4)
+
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def __post_init__(self):
+        self._validate_category()
+
+    def _validate_category(self) -> None:
+        if not self.name or not self.name.strip():
+            raise DomainValidationError("Category name cannot be empty")
+
+        if not self.owner_id or not str(self.owner_id).strip():
+            raise DomainValidationError("owner_id cannot be empty")
+
+        self.name = self.name.strip()
+
+    def rename(self, new_name: str) -> None:
+        if not new_name or not new_name.strip():
+            raise DomainValidationError("Category name cannot be empty")
+
+        self.name = new_name.strip()
+        self.updated_at = datetime.now(timezone.utc)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "name": self.name,
+            "owner_id": self.owner_id,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Category":
+        return cls(
+            id=uuid.UUID(data["id"]),
+            name=data["name"],
+            owner_id=data["owner_id"],
+            created_at=datetime.fromisoformat(data["created_at"]),
+            updated_at=datetime.fromisoformat(data["updated_at"]),
+        )
+
+    def __str__(self) -> str:
+        return f"Category(id={self.id}, name='{self.name}')"
+
+    def __repr__(self) -> str:
+        return f"Category(id={self.id}, name='{self.name}', owner_id={self.owner_id})"

--- a/django/apps/decks/domain/entities/deck.py
+++ b/django/apps/decks/domain/entities/deck.py
@@ -11,18 +11,19 @@ Cada deck tem:
 """
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional, Set
 from dataclasses import dataclass, field
 
 from .card import Card
+from ..exceptions import DomainValidationError
 
 
 @dataclass
 class Deck:
     """
     Entidade Deck representa uma coleção de cards do Anki.
-    
+
     Atributos:
     - title: Título do deck
     - id: Identificador único (UUID)
@@ -32,74 +33,80 @@ class Deck:
     - created_at: Data de criação
     - updated_at: Data da última atualização
     """
-    
+
     # Propriedades básicas (obrigatórias)
     title: str
-    
+    owner_id: str
+
     # Identidade única da entidade
     id: uuid.UUID = field(default_factory=uuid.uuid4)
-    
+
     # Campos opcionais
     description: str = ""
-    
+    category_id: Optional[uuid.UUID] = None
+
     # Cards do deck
     cards: List[Card] = field(default_factory=list)
-    
+
     # Configurações
     max_cards_per_generation: int = 10
-    
+
     # Metadados
-    created_at: datetime = field(default_factory=datetime.utcnow)
-    updated_at: datetime = field(default_factory=datetime.utcnow)
-    
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
     def __post_init__(self):
         """
         Validações que são executadas após a criação do objeto.
         """
         self._validate_deck()
-    
+
     def _validate_deck(self) -> None:
         """
         Valida se o deck está em estado válido.
-        
+
         Regras de negócio:
         1. Título não pode estar vazio
         2. Máximo de cards por geração deve ser entre 1 e 20
         3. Descrição pode ser vazia mas não None
+        4. owner_id é obrigatório (isolamento multi-tenant)
         """
         if not self.title or not self.title.strip():
-            raise ValueError("Deck title cannot be empty")
-        
+            raise DomainValidationError("Deck title cannot be empty")
+
         if not (1 <= self.max_cards_per_generation <= 20):
-            raise ValueError("Max cards per generation must be between 1 and 20")
-        
+            raise DomainValidationError("Max cards per generation must be between 1 and 20")
+
         if self.description is None:
             self.description = ""
-        
+
+        if not self.owner_id or not str(self.owner_id).strip():
+            raise DomainValidationError("owner_id cannot be empty")
+
         # Normaliza o título
         self.title = self.title.strip()
-    
+
     @property
     def card_count(self) -> int:
         """
         Retorna o número de cards no deck.
         """
         return len(self.cards)
-    
+
     @property
     def is_empty(self) -> bool:
         """
         Verifica se o deck está vazio.
         """
         return self.card_count == 0
-    
+
     @property
     def has_cards(self) -> bool:
         """
         Verifica se o deck tem cards.
         """
         return self.card_count > 0
-    
+
     @property
     def unique_words(self) -> Set[str]:
         """
@@ -107,141 +114,141 @@ class Deck:
         Útil para verificação de duplicatas.
         """
         return {card.word.normalized for card in self.cards}
-    
+
     @property
     def contexts_used(self) -> Set[str]:
         """
         Retorna um conjunto com todos os contextos usados no deck.
         """
         return {card.context for card in self.cards if card.context}
-    
+
     def add_card(self, card: Card) -> None:
         """
         Adiciona um card ao deck.
-        
+
         Regras de negócio:
         1. Card não pode ser None
         2. Card deve ser associado ao deck
         3. Atualiza timestamp de modificação
         """
         if card is None:
-            raise ValueError("Card cannot be None")
-        
+            raise DomainValidationError("Card cannot be None")
+
         # Associa o card ao deck
         card.assign_to_deck(self.id)
-        
+
         # Adiciona o card à lista
         self.cards.append(card)
-        
+
         # Atualiza timestamp
-        self.updated_at = datetime.utcnow()
-    
+        self.updated_at = datetime.now(timezone.utc)
+
     def add_cards(self, cards: List[Card]) -> None:
         """
         Adiciona múltiplos cards ao deck.
-        
+
         Args:
             cards: Lista de cards para adicionar
         """
         if not cards:
             return
-        
+
         for card in cards:
             self.add_card(card)
-    
+
     def remove_card(self, card_id: uuid.UUID) -> bool:
         """
         Remove um card do deck.
-        
+
         Args:
             card_id: ID do card a ser removido
-            
+
         Returns:
             True se o card foi removido, False se não foi encontrado
         """
         for i, card in enumerate(self.cards):
             if card.id == card_id:
                 del self.cards[i]
-                self.updated_at = datetime.utcnow()
+                self.updated_at = datetime.now(timezone.utc)
                 return True
-        
+
         return False
-    
+
     def get_card_by_id(self, card_id: uuid.UUID) -> Optional[Card]:
         """
         Busca um card pelo ID.
-        
+
         Args:
             card_id: ID do card
-            
+
         Returns:
             Card se encontrado, None caso contrário
         """
         for card in self.cards:
             if card.id == card_id:
                 return card
-        
+
         return None
-    
+
     def get_cards_by_context(self, context: str) -> List[Card]:
         """
         Busca cards por contexto.
-        
+
         Args:
             context: Contexto para buscar
-            
+
         Returns:
             Lista de cards que usam o contexto especificado
         """
         return [card for card in self.cards if card.context == context]
-    
+
     def has_word(self, word: str) -> bool:
         """
         Verifica se o deck já contém uma palavra específica.
-        
+
         Args:
             word: Palavra para verificar
-            
+
         Returns:
             True se a palavra já existe no deck
         """
         word_normalized = word.lower().strip()
         return word_normalized in self.unique_words
-    
+
     def find_similar_card(self, word: str) -> Optional[Card]:
         """
         Busca um card similar à palavra especificada.
-        
+
         Args:
             word: Palavra para buscar
-            
+
         Returns:
             Card similar se encontrado, None caso contrário
         """
         word_normalized = word.lower().strip()
-        
+
         for card in self.cards:
             if card.word.normalized == word_normalized:
                 return card
-        
+
         return None
-    
+
     def can_add_more_cards(self, count: int = 1) -> bool:
         """
         Verifica se pode adicionar mais cards sem exceder o limite.
-        
+
         Args:
             count: Número de cards que se deseja adicionar
-            
+
         Returns:
             True se pode adicionar, False caso contrário
         """
         return self.card_count + count <= self.max_cards_per_generation * 10  # Limite razoável
-    
+
     def get_generation_batches(self) -> List[List[Card]]:
         """
         Divide os cards em lotes para geração.
-        
+
         Returns:
             Lista de lotes, cada um com até max_cards_per_generation cards
         """
@@ -249,42 +256,42 @@ class Deck:
         for i in range(0, len(self.cards), self.max_cards_per_generation):
             batch = self.cards[i:i + self.max_cards_per_generation]
             batches.append(batch)
-        
+
         return batches
-    
+
     def update_title(self, new_title: str) -> None:
         """
         Atualiza o título do deck.
-        
+
         Args:
             new_title: Novo título
         """
         if not new_title or not new_title.strip():
-            raise ValueError("Deck title cannot be empty")
-        
+            raise DomainValidationError("Deck title cannot be empty")
+
         self.title = new_title.strip()
-        self.updated_at = datetime.utcnow()
-    
+        self.updated_at = datetime.now(timezone.utc)
+
     def update_description(self, new_description: str) -> None:
         """
         Atualiza a descrição do deck.
-        
+
         Args:
             new_description: Nova descrição
         """
         if new_description is None:
             new_description = ""
-        
+
         self.description = new_description
-        self.updated_at = datetime.utcnow()
-    
+        self.updated_at = datetime.now(timezone.utc)
+
     def clear_cards(self) -> None:
         """
         Remove todos os cards do deck.
         """
         self.cards.clear()
-        self.updated_at = datetime.utcnow()
-    
+        self.updated_at = datetime.now(timezone.utc)
+
     def to_dict(self) -> dict:
         """
         Converte o deck para dicionário.
@@ -292,7 +299,9 @@ class Deck:
         return {
             "id": str(self.id),
             "title": self.title,
+            "owner_id": self.owner_id,
             "description": self.description,
+            "category_id": str(self.category_id) if self.category_id else None,
             "cards": [card.to_dict() for card in self.cards],
             "max_cards_per_generation": self.max_cards_per_generation,
             "created_at": self.created_at.isoformat(),
@@ -300,7 +309,7 @@ class Deck:
             "card_count": self.card_count,
             "is_empty": self.is_empty
         }
-    
+
     @classmethod
     def from_dict(cls, data: dict) -> 'Deck':
         """
@@ -309,22 +318,24 @@ class Deck:
         deck = cls(
             id=uuid.UUID(data["id"]),
             title=data["title"],
+            owner_id=data["owner_id"],
             description=data.get("description", ""),
+            category_id=uuid.UUID(data["category_id"]) if data.get("category_id") else None,
             max_cards_per_generation=data.get("max_cards_per_generation", 10),
             created_at=datetime.fromisoformat(data["created_at"]),
             updated_at=datetime.fromisoformat(data["updated_at"])
         )
-        
+
         # Adiciona os cards
         cards_data = data.get("cards", [])
         for card_data in cards_data:
             card = Card.from_dict(card_data)
             deck.cards.append(card)
-        
+
         return deck
-    
+
     def __str__(self) -> str:
         return f"Deck(id={self.id}, title='{self.title}', cards={self.card_count})"
-    
+
     def __repr__(self) -> str:
         return f"Deck(id={self.id}, title='{self.title}', cards={self.card_count}, created_at={self.created_at})"

--- a/django/apps/decks/domain/entities/generation_session.py
+++ b/django/apps/decks/domain/entities/generation_session.py
@@ -10,12 +10,13 @@ Ela controla:
 """
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import List, Optional
 from dataclasses import dataclass, field
 
 from .card import Card
+from ..exceptions import DomainValidationError
 
 
 class GenerationStatus(Enum):
@@ -33,7 +34,7 @@ class GenerationStatus(Enum):
 class GenerationSession:
     """
     Entidade GenerationSession controla uma sessão de geração de cards.
-    
+
     Atributos:
     - context: Contexto fornecido pelo usuário
     - deck_id: ID do deck associado
@@ -46,101 +47,101 @@ class GenerationSession:
     - completed_at: Data de conclusão (se aplicável)
     - error_message: Mensagem de erro (se aplicável)
     """
-    
+
     # Propriedades da sessão (obrigatórias)
     context: str
     deck_id: uuid.UUID
-    
+
     # Identidade única da entidade
     id: uuid.UUID = field(default_factory=uuid.uuid4)
-    
+
     # Status e controle
     status: GenerationStatus = GenerationStatus.PENDING
     generated_cards: List[Card] = field(default_factory=list)
     max_cards: int = 10
-    
+
     # Metadados
-    created_at: datetime = field(default_factory=datetime.utcnow)
-    updated_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: Optional[datetime] = None
     error_message: Optional[str] = None
-    
+
     def __post_init__(self):
         """
         Validações que são executadas após a criação do objeto.
         """
         self._validate_session()
-    
+
     def _validate_session(self) -> None:
         """
         Valida se a sessão está em estado válido.
-        
+
         Regras de negócio:
         1. Contexto não pode estar vazio
         2. Máximo de cards deve ser entre 1 e 20
         3. Deck ID não pode ser None
         """
         if not self.context or not self.context.strip():
-            raise ValueError("Context cannot be empty")
-        
+            raise DomainValidationError("Context cannot be empty")
+
         if not (1 <= self.max_cards <= 20):
-            raise ValueError("Max cards must be between 1 and 20")
-        
+            raise DomainValidationError("Max cards must be between 1 and 20")
+
         if self.deck_id is None:
-            raise ValueError("Deck ID cannot be None")
-        
+            raise DomainValidationError("Deck ID cannot be None")
+
         # Normaliza o contexto
         self.context = self.context.strip()
-    
+
     @property
     def cards_generated_count(self) -> int:
         """
         Retorna o número de cards gerados na sessão.
         """
         return len(self.generated_cards)
-    
+
     @property
     def is_pending(self) -> bool:
         """
         Verifica se a sessão está pendente.
         """
         return self.status == GenerationStatus.PENDING
-    
+
     @property
     def is_in_progress(self) -> bool:
         """
         Verifica se a sessão está em andamento.
         """
         return self.status == GenerationStatus.IN_PROGRESS
-    
+
     @property
     def is_completed(self) -> bool:
         """
         Verifica se a sessão foi concluída.
         """
         return self.status == GenerationStatus.COMPLETED
-    
+
     @property
     def is_failed(self) -> bool:
         """
         Verifica se a sessão falhou.
         """
         return self.status == GenerationStatus.FAILED
-    
+
     @property
     def is_cancelled(self) -> bool:
         """
         Verifica se a sessão foi cancelada.
         """
         return self.status == GenerationStatus.CANCELLED
-    
+
     @property
     def is_finished(self) -> bool:
         """
         Verifica se a sessão foi finalizada (concluída, falhou ou cancelada).
         """
         return self.status in [GenerationStatus.COMPLETED, GenerationStatus.FAILED, GenerationStatus.CANCELLED]
-    
+
     @property
     def can_add_cards(self) -> bool:
         """
@@ -150,97 +151,97 @@ class GenerationSession:
             self.status in [GenerationStatus.PENDING, GenerationStatus.IN_PROGRESS] and
             self.cards_generated_count < self.max_cards
         )
-    
+
     def start_generation(self) -> None:
         """
         Inicia a geração de cards.
-        
+
         Regras de negócio:
         1. Só pode iniciar se estiver pendente
         2. Atualiza status para IN_PROGRESS
         """
         if not self.is_pending:
-            raise ValueError(f"Cannot start generation. Current status: {self.status.value}")
-        
+            raise DomainValidationError(f"Cannot start generation. Current status: {self.status.value}")
+
         self.status = GenerationStatus.IN_PROGRESS
-        self.updated_at = datetime.utcnow()
-    
+        self.updated_at = datetime.now(timezone.utc)
+
     def add_generated_card(self, card: Card) -> None:
         """
         Adiciona um card gerado à sessão.
-        
+
         Regras de negócio:
         1. Só pode adicionar se a sessão permitir
         2. Card deve ser associado ao deck da sessão
         3. Não pode exceder o máximo de cards
         """
         if not self.can_add_cards:
-            raise ValueError(f"Cannot add card. Status: {self.status.value}, Cards: {self.cards_generated_count}/{self.max_cards}")
-        
+            raise DomainValidationError(f"Cannot add card. Status: {self.status.value}, Cards: {self.cards_generated_count}/{self.max_cards}")
+
         if card is None:
-            raise ValueError("Card cannot be None")
-        
+            raise DomainValidationError("Card cannot be None")
+
         # Associa o card ao deck da sessão
         card.assign_to_deck(self.deck_id)
-        
+
         # Adiciona o card
         self.generated_cards.append(card)
-        
+
         # Atualiza timestamp
-        self.updated_at = datetime.utcnow()
-    
+        self.updated_at = datetime.now(timezone.utc)
+
     def complete_generation(self) -> None:
         """
         Marca a sessão como concluída.
-        
+
         Regras de negócio:
         1. Só pode concluir se estiver em andamento
         2. Deve ter pelo menos um card gerado
         3. Atualiza timestamp de conclusão
         """
         if not self.is_in_progress:
-            raise ValueError(f"Cannot complete generation. Current status: {self.status.value}")
-        
+            raise DomainValidationError(f"Cannot complete generation. Current status: {self.status.value}")
+
         if self.cards_generated_count == 0:
-            raise ValueError("Cannot complete generation without any cards")
-        
+            raise DomainValidationError("Cannot complete generation without any cards")
+
         self.status = GenerationStatus.COMPLETED
-        self.completed_at = datetime.utcnow()
-        self.updated_at = datetime.utcnow()
-    
+        self.completed_at = datetime.now(timezone.utc)
+        self.updated_at = datetime.now(timezone.utc)
+
     def fail_generation(self, error_message: str) -> None:
         """
         Marca a sessão como falhada.
-        
+
         Args:
             error_message: Mensagem descritiva do erro
         """
         if self.is_finished:
-            raise ValueError(f"Cannot fail generation. Current status: {self.status.value}")
-        
+            raise DomainValidationError(f"Cannot fail generation. Current status: {self.status.value}")
+
         self.status = GenerationStatus.FAILED
         self.error_message = error_message
-        self.completed_at = datetime.utcnow()
-        self.updated_at = datetime.utcnow()
-    
+        self.completed_at = datetime.now(timezone.utc)
+        self.updated_at = datetime.now(timezone.utc)
+
     def cancel_generation(self) -> None:
         """
         Cancela a sessão de geração.
         """
         if self.is_finished:
-            raise ValueError(f"Cannot cancel generation. Current status: {self.status.value}")
-        
+            raise DomainValidationError(f"Cannot cancel generation. Current status: {self.status.value}")
+
         self.status = GenerationStatus.CANCELLED
-        self.completed_at = datetime.utcnow()
-        self.updated_at = datetime.utcnow()
-    
+        self.completed_at = datetime.now(timezone.utc)
+        self.updated_at = datetime.now(timezone.utc)
+
     def get_cards_by_word(self, word: str) -> List[Card]:
         """
         Busca cards gerados por palavra.
-        
+
         Args:
             word: Palavra para buscar
-            
+
         Returns:
             Lista de cards que contêm a palavra
         """
@@ -249,25 +250,25 @@ class GenerationSession:
             card for card in self.generated_cards
             if card.word.normalized == word_normalized
         ]
-    
+
     def has_duplicate_word(self, word: str) -> bool:
         """
         Verifica se já existe um card com a palavra especificada.
-        
+
         Args:
             word: Palavra para verificar
-            
+
         Returns:
             True se já existe um card com essa palavra
         """
         return len(self.get_cards_by_word(word)) > 0
-    
+
     def get_unique_words(self) -> List[str]:
         """
         Retorna lista de palavras únicas geradas na sessão.
         """
         return list(set(card.word.normalized for card in self.generated_cards))
-    
+
     def to_dict(self) -> dict:
         """
         Converte a sessão para dicionário.
@@ -286,7 +287,7 @@ class GenerationSession:
             "cards_generated_count": self.cards_generated_count,
             "is_finished": self.is_finished
         }
-    
+
     @classmethod
     def from_dict(cls, data: dict) -> 'GenerationSession':
         """
@@ -303,17 +304,17 @@ class GenerationSession:
             completed_at=datetime.fromisoformat(data["completed_at"]) if data.get("completed_at") else None,
             error_message=data.get("error_message")
         )
-        
+
         # Adiciona os cards gerados
         cards_data = data.get("generated_cards", [])
         for card_data in cards_data:
             card = Card.from_dict(card_data)
             session.generated_cards.append(card)
-        
+
         return session
-    
+
     def __str__(self) -> str:
         return f"GenerationSession(id={self.id}, status={self.status.value}, cards={self.cards_generated_count})"
-    
+
     def __repr__(self) -> str:
         return f"GenerationSession(id={self.id}, status={self.status.value}, cards={self.cards_generated_count}, context='{self.context[:30]}...')"

--- a/django/apps/decks/domain/exceptions.py
+++ b/django/apps/decks/domain/exceptions.py
@@ -1,0 +1,14 @@
+"""
+Exceções de validação de domínio. Toda violação de invariante em
+entidades/objetos de valor (`Card`, `Deck`, `Category`, `CardReview`,
+`Word`, `Translation`, `Example`, `AudioPath`, `GenerationSession`) usa
+`DomainValidationError` em vez de `ValueError` puro — quem captura sabe
+que é "um erro de validação nosso" via `except DomainValidationError`
+(que por sua vez é um `except AppError`, ver core/exceptions.py).
+"""
+
+from core.exceptions import AppError
+
+
+class DomainValidationError(AppError):
+    code = "domain_validation_error"

--- a/django/apps/decks/domain/repositories/__init__.py
+++ b/django/apps/decks/domain/repositories/__init__.py
@@ -14,10 +14,14 @@ Características dos Repositórios:
 
 from .icard_repository import ICardRepository
 from .ideck_repository import IDeckRepository
+from .icategory_repository import ICategoryRepository
+from .icard_review_repository import ICardReviewRepository
 from .igeneration_session_repository import IGenerationSessionRepository
 
 __all__ = [
     'ICardRepository',
     'IDeckRepository',
+    'ICategoryRepository',
+    'ICardReviewRepository',
     'IGenerationSessionRepository'
 ]

--- a/django/apps/decks/domain/repositories/icard_repository.py
+++ b/django/apps/decks/domain/repositories/icard_repository.py
@@ -1,264 +1,87 @@
 """
 Interface ICardRepository - Define operações de persistência para Cards
 
-Esta interface define todas as operações necessárias para persistir e recuperar
-cards do banco de dados. A implementação concreta ficará na camada de infraestrutura.
-
-Princípios:
-- Interface segregation: Define apenas operações específicas para Cards
-- Dependency inversion: O domínio depende da abstração, não da implementação
-- Single responsibility: Responsável apenas por operações de Card
+Toda operação de leitura/escrita que localiza um card por ID ou por outro
+filtro exige `owner_id` como parâmetro obrigatório, embutido diretamente no
+filtro da consulta — nunca conferido depois em Python (ver D1 em
+openspec/changes/sprint-2-decks-cards/design.md, `<ponto_critico
+id="isolamento-multi-tenant">` em PROMPT_REFINADO.md).
 """
 
 import uuid
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import List, Optional
 from ..entities.card import Card
 
 
 class ICardRepository(ABC):
-    """
-    Interface para repositório de Cards.
-    
-    Define todas as operações de persistência necessárias para a entidade Card.
-    """
-    
+    """Interface para repositório de Cards."""
+
     @abstractmethod
     async def save(self, card: Card) -> Card:
-        """
-        Salva um card no banco de dados.
-        
-        Args:
-            card: Card a ser salvo
-            
-        Returns:
-            Card salvo (com ID gerado se for novo)
-            
-        Raises:
-            RepositoryError: Se houver erro na persistência
-        """
+        """Salva um card (owner_id já vem embutido na entidade)."""
         pass
-    
+
     @abstractmethod
     async def save_many(self, cards: List[Card]) -> List[Card]:
-        """
-        Salva múltiplos cards no banco de dados.
-        
-        Args:
-            cards: Lista de cards a serem salvos
-            
-        Returns:
-            Lista de cards salvos
-            
-        Raises:
-            RepositoryError: Se houver erro na persistência
-        """
+        """Salva múltiplos cards (owner_id já vem embutido em cada entidade)."""
         pass
-    
+
     @abstractmethod
-    async def find_by_id(self, card_id: uuid.UUID) -> Optional[Card]:
-        """
-        Busca um card pelo ID.
-        
-        Args:
-            card_id: ID do card
-            
-        Returns:
-            Card se encontrado, None caso contrário
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+    async def find_by_id(self, card_id: uuid.UUID, owner_id: str) -> Optional[Card]:
         pass
-    
+
     @abstractmethod
-    async def find_by_word(self, word: str) -> List[Card]:
-        """
-        Busca cards por palavra.
-        
-        Args:
-            word: Palavra para buscar (case insensitive)
-            
-        Returns:
-            Lista de cards que contêm a palavra
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+    async def find_by_word(self, word: str, owner_id: str) -> List[Card]:
         pass
-    
+
     @abstractmethod
-    async def find_by_deck_id(self, deck_id: uuid.UUID) -> List[Card]:
-        """
-        Busca todos os cards de um deck.
-        
-        Args:
-            deck_id: ID do deck
-            
-        Returns:
-            Lista de cards do deck
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+    async def find_by_deck_id(self, deck_id: uuid.UUID, owner_id: str) -> List[Card]:
         pass
-    
+
     @abstractmethod
-    async def find_by_context(self, context: str) -> List[Card]:
-        """
-        Busca cards por contexto.
-        
-        Args:
-            context: Contexto para buscar
-            
-        Returns:
-            Lista de cards que usam o contexto
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+    async def find_by_context(self, context: str, owner_id: str) -> List[Card]:
         pass
-    
+
     @abstractmethod
-    async def find_similar_cards(self, word: str, similarity_threshold: float = 0.8) -> List[Card]:
-        """
-        Busca cards similares à palavra especificada.
-        
-        Args:
-            word: Palavra para comparar
-            similarity_threshold: Limiar de similaridade (0.0 a 1.0)
-            
-        Returns:
-            Lista de cards similares
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+    async def find_similar_cards(self, word: str, owner_id: str, similarity_threshold: float = 0.8) -> List[Card]:
         pass
-    
+
     @abstractmethod
-    async def find_duplicates(self, card: Card) -> List[Card]:
-        """
-        Busca cards duplicados ou muito similares.
-        
-        Args:
-            card: Card para verificar duplicatas
-            
-        Returns:
-            Lista de cards duplicados/similares
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+    async def find_duplicates(self, card: Card, owner_id: str) -> List[Card]:
         pass
-    
+
+    @abstractmethod
+    async def find_due(self, owner_id: str, due_before: Optional[datetime] = None) -> List[Card]:
+        """Cards devidos (`due_at <= due_before`, default agora) para um owner."""
+        pass
+
     @abstractmethod
     async def update(self, card: Card) -> Card:
-        """
-        Atualiza um card existente.
-        
-        Args:
-            card: Card com dados atualizados
-            
-        Returns:
-            Card atualizado
-            
-        Raises:
-            RepositoryError: Se houver erro na atualização
-            CardNotFoundError: Se o card não existir
-        """
+        """Atualiza um card (filtro embute `_id` + `card.owner_id`)."""
         pass
-    
+
     @abstractmethod
-    async def delete(self, card_id: uuid.UUID) -> bool:
-        """
-        Remove um card do banco de dados.
-        
-        Args:
-            card_id: ID do card a ser removido
-            
-        Returns:
-            True se o card foi removido, False se não foi encontrado
-            
-        Raises:
-            RepositoryError: Se houver erro na remoção
-        """
+    async def delete(self, card_id: uuid.UUID, owner_id: str) -> bool:
         pass
-    
+
     @abstractmethod
-    async def delete_by_deck_id(self, deck_id: uuid.UUID) -> int:
-        """
-        Remove todos os cards de um deck.
-        
-        Args:
-            deck_id: ID do deck
-            
-        Returns:
-            Número de cards removidos
-            
-        Raises:
-            RepositoryError: Se houver erro na remoção
-        """
+    async def delete_by_deck_id(self, deck_id: uuid.UUID, owner_id: str) -> int:
         pass
-    
+
     @abstractmethod
-    async def count(self) -> int:
-        """
-        Conta o total de cards no banco.
-        
-        Returns:
-            Número total de cards
-            
-        Raises:
-            RepositoryError: Se houver erro na contagem
-        """
+    async def count(self, owner_id: str) -> int:
         pass
-    
+
     @abstractmethod
-    async def count_by_deck_id(self, deck_id: uuid.UUID) -> int:
-        """
-        Conta o número de cards de um deck.
-        
-        Args:
-            deck_id: ID do deck
-            
-        Returns:
-            Número de cards do deck
-            
-        Raises:
-            RepositoryError: Se houver erro na contagem
-        """
+    async def count_by_deck_id(self, deck_id: uuid.UUID, owner_id: str) -> int:
         pass
-    
+
     @abstractmethod
-    async def exists(self, card_id: uuid.UUID) -> bool:
-        """
-        Verifica se um card existe.
-        
-        Args:
-            card_id: ID do card
-            
-        Returns:
-            True se o card existe, False caso contrário
-            
-        Raises:
-            RepositoryError: Se houver erro na verificação
-        """
+    async def exists(self, card_id: uuid.UUID, owner_id: str) -> bool:
         pass
-    
+
     @abstractmethod
-    async def exists_by_word(self, word: str, deck_id: Optional[uuid.UUID] = None) -> bool:
-        """
-        Verifica se já existe um card com a palavra especificada.
-        
-        Args:
-            word: Palavra para verificar
-            deck_id: ID do deck (opcional, para verificar apenas em um deck)
-            
-        Returns:
-            True se já existe um card com essa palavra
-            
-        Raises:
-            RepositoryError: Se houver erro na verificação
-        """
+    async def exists_by_word(self, word: str, owner_id: str, deck_id: Optional[uuid.UUID] = None) -> bool:
         pass

--- a/django/apps/decks/domain/repositories/icard_review_repository.py
+++ b/django/apps/decks/domain/repositories/icard_review_repository.py
@@ -1,0 +1,22 @@
+"""
+Interface ICardReviewRepository - Define operações de persistência para
+CardReview (um documento por evento de revisão, ver D5 em
+openspec/changes/sprint-2-decks-cards/design.md).
+"""
+
+import uuid
+from abc import ABC, abstractmethod
+from typing import List
+from ..entities.card_review import CardReview
+
+
+class ICardReviewRepository(ABC):
+    """Interface para repositório de CardReview."""
+
+    @abstractmethod
+    async def save(self, review: CardReview) -> CardReview:
+        pass
+
+    @abstractmethod
+    async def find_by_card_id(self, card_id: uuid.UUID, owner_id: str) -> List[CardReview]:
+        pass

--- a/django/apps/decks/domain/repositories/icategory_repository.py
+++ b/django/apps/decks/domain/repositories/icategory_repository.py
@@ -1,0 +1,39 @@
+"""
+Interface ICategoryRepository - Define operações de persistência para Category
+
+Mesmo padrão de owner_id obrigatório dos demais repositórios (ver D1/D6 em
+openspec/changes/sprint-2-decks-cards/design.md).
+"""
+
+import uuid
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from ..entities.category import Category
+
+
+class ICategoryRepository(ABC):
+    """Interface para repositório de Categories."""
+
+    @abstractmethod
+    async def save(self, category: Category) -> Category:
+        pass
+
+    @abstractmethod
+    async def find_by_id(self, category_id: uuid.UUID, owner_id: str) -> Optional[Category]:
+        pass
+
+    @abstractmethod
+    async def find_all(self, owner_id: str) -> List[Category]:
+        pass
+
+    @abstractmethod
+    async def update(self, category: Category) -> Category:
+        pass
+
+    @abstractmethod
+    async def delete(self, category_id: uuid.UUID, owner_id: str) -> bool:
+        pass
+
+    @abstractmethod
+    async def exists(self, category_id: uuid.UUID, owner_id: str) -> bool:
+        pass

--- a/django/apps/decks/domain/repositories/ideck_repository.py
+++ b/django/apps/decks/domain/repositories/ideck_repository.py
@@ -1,8 +1,10 @@
 """
 Interface IDeckRepository - Define operações de persistência para Decks
 
-Esta interface define todas as operações necessárias para persistir e recuperar
-decks do banco de dados.
+Toda operação de leitura/escrita que localiza um deck por ID ou por outro
+filtro exige `owner_id` como parâmetro obrigatório, embutido diretamente no
+filtro da consulta (ver D1 em
+openspec/changes/sprint-2-decks-cards/design.md).
 """
 
 import uuid
@@ -12,186 +14,50 @@ from ..entities.deck import Deck
 
 
 class IDeckRepository(ABC):
-    """
-    Interface para repositório de Decks.
-    
-    Define todas as operações de persistência necessárias para a entidade Deck.
-    """
-    
+    """Interface para repositório de Decks."""
+
     @abstractmethod
     async def save(self, deck: Deck) -> Deck:
-        """
-        Salva um deck no banco de dados.
-        
-        Args:
-            deck: Deck a ser salvo
-            
-        Returns:
-            Deck salvo (com ID gerado se for novo)
-            
-        Raises:
-            RepositoryError: Se houver erro na persistência
-        """
+        """Salva um deck (owner_id já vem embutido na entidade)."""
         pass
-    
+
     @abstractmethod
-    async def find_by_id(self, deck_id: uuid.UUID) -> Optional[Deck]:
-        """
-        Busca um deck pelo ID.
-        
-        Args:
-            deck_id: ID do deck
-            
-        Returns:
-            Deck se encontrado, None caso contrário
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+    async def find_by_id(self, deck_id: uuid.UUID, owner_id: str) -> Optional[Deck]:
         pass
-    
+
     @abstractmethod
-    async def find_by_title(self, title: str) -> List[Deck]:
-        """
-        Busca decks por título.
-        
-        Args:
-            title: Título para buscar (case insensitive)
-            
-        Returns:
-            Lista de decks com títulos similares
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+    async def find_by_title(self, title: str, owner_id: str) -> List[Deck]:
         pass
-    
+
     @abstractmethod
-    async def find_all(self, skip: int = 0, limit: int = 100) -> List[Deck]:
-        """
-        Busca todos os decks com paginação.
-        
-        Args:
-            skip: Número de registros para pular
-            limit: Número máximo de registros a retornar
-            
-        Returns:
-            Lista de decks
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+    async def find_all(self, owner_id: str, skip: int = 0, limit: int = 100) -> List[Deck]:
         pass
-    
+
     @abstractmethod
     async def find_by_user_id(self, user_id: str, skip: int = 0, limit: int = 100) -> List[Deck]:
-        """
-        Busca decks de um usuário específico.
-        
-        Args:
-            user_id: ID do usuário
-            skip: Número de registros para pular
-            limit: Número máximo de registros a retornar
-            
-        Returns:
-            Lista de decks do usuário
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
         pass
-    
+
     @abstractmethod
     async def update(self, deck: Deck) -> Deck:
-        """
-        Atualiza um deck existente.
-        
-        Args:
-            deck: Deck com dados atualizados
-            
-        Returns:
-            Deck atualizado
-            
-        Raises:
-            RepositoryError: Se houver erro na atualização
-            DeckNotFoundError: Se o deck não existir
-        """
+        """Atualiza um deck (filtro embute `_id` + `deck.owner_id`)."""
         pass
-    
+
     @abstractmethod
-    async def delete(self, deck_id: uuid.UUID) -> bool:
-        """
-        Remove um deck do banco de dados.
-        
-        Args:
-            deck_id: ID do deck a ser removido
-            
-        Returns:
-            True se o deck foi removido, False se não foi encontrado
-            
-        Raises:
-            RepositoryError: Se houver erro na remoção
-        """
+    async def delete(self, deck_id: uuid.UUID, owner_id: str) -> bool:
         pass
-    
+
     @abstractmethod
-    async def count(self) -> int:
-        """
-        Conta o total de decks no banco.
-        
-        Returns:
-            Número total de decks
-            
-        Raises:
-            RepositoryError: Se houver erro na contagem
-        """
+    async def count(self, owner_id: str) -> int:
         pass
-    
+
     @abstractmethod
     async def count_by_user_id(self, user_id: str) -> int:
-        """
-        Conta o número de decks de um usuário.
-        
-        Args:
-            user_id: ID do usuário
-            
-        Returns:
-            Número de decks do usuário
-            
-        Raises:
-            RepositoryError: Se houver erro na contagem
-        """
         pass
-    
+
     @abstractmethod
-    async def exists(self, deck_id: uuid.UUID) -> bool:
-        """
-        Verifica se um deck existe.
-        
-        Args:
-            deck_id: ID do deck
-            
-        Returns:
-            True se o deck existe, False caso contrário
-            
-        Raises:
-            RepositoryError: Se houver erro na verificação
-        """
+    async def exists(self, deck_id: uuid.UUID, owner_id: str) -> bool:
         pass
-    
+
     @abstractmethod
-    async def exists_by_title(self, title: str, user_id: Optional[str] = None) -> bool:
-        """
-        Verifica se já existe um deck com o título especificado.
-        
-        Args:
-            title: Título para verificar
-            user_id: ID do usuário (opcional, para verificar apenas para um usuário)
-            
-        Returns:
-            True se já existe um deck com esse título
-            
-        Raises:
-            RepositoryError: Se houver erro na verificação
-        """
+    async def exists_by_title(self, title: str, owner_id: str) -> bool:
         pass

--- a/django/apps/decks/domain/repositories/igeneration_session_repository.py
+++ b/django/apps/decks/domain/repositories/igeneration_session_repository.py
@@ -14,260 +14,265 @@ from ..entities.generation_session import GenerationSession, GenerationStatus
 class IGenerationSessionRepository(ABC):
     """
     Interface para repositório de GenerationSessions.
-    
+
     Define todas as operações de persistência necessárias para a entidade GenerationSession.
     """
-    
+
     @abstractmethod
     async def save(self, session: GenerationSession) -> GenerationSession:
         """
         Salva uma sessão de geração no banco de dados.
-        
+
         Args:
             session: Sessão a ser salva
-            
+
         Returns:
             Sessão salva (com ID gerado se for nova)
-            
+
         Raises:
             RepositoryError: Se houver erro na persistência
         """
         pass
-    
+
     @abstractmethod
-    async def find_by_id(self, session_id: uuid.UUID) -> Optional[GenerationSession]:
+    async def find_by_id(self, session_id: uuid.UUID, owner_id: str) -> Optional[GenerationSession]:
         """
-        Busca uma sessão pelo ID.
-        
+        Busca uma sessão pelo ID. `owner_id` é repassado ao `CardRepository`
+        ao carregar `generated_cards` — desde a Sprint 2, todo acesso a
+        `Card` exige owner_id (ver D1 em
+        openspec/changes/sprint-2-decks-cards/design.md); `GenerationSession`
+        em si continua sem campo de dono próprio (D5).
+
         Args:
             session_id: ID da sessão
-            
+            owner_id: dono dos cards do deck associado
+
         Returns:
             Sessão se encontrada, None caso contrário
-            
+
         Raises:
             RepositoryError: Se houver erro na consulta
         """
         pass
-    
+
     @abstractmethod
     async def find_by_deck_id(self, deck_id: uuid.UUID) -> List[GenerationSession]:
         """
         Busca todas as sessões de um deck.
-        
+
         Args:
             deck_id: ID do deck
-            
+
         Returns:
             Lista de sessões do deck
-            
+
         Raises:
             RepositoryError: Se houver erro na consulta
         """
         pass
-    
+
     @abstractmethod
     async def find_by_status(self, status: GenerationStatus) -> List[GenerationSession]:
         """
         Busca sessões por status.
-        
+
         Args:
             status: Status das sessões
-            
+
         Returns:
             Lista de sessões com o status especificado
-            
+
         Raises:
             RepositoryError: Se houver erro na consulta
         """
         pass
-    
+
     @abstractmethod
     async def find_by_context(self, context: str) -> List[GenerationSession]:
         """
         Busca sessões por contexto.
-        
+
         Args:
             context: Contexto para buscar
-            
+
         Returns:
             Lista de sessões que usam o contexto
-            
+
         Raises:
             RepositoryError: Se houver erro na consulta
         """
         pass
-    
+
     @abstractmethod
     async def find_active_sessions(self, deck_id: Optional[uuid.UUID] = None) -> List[GenerationSession]:
         """
         Busca sessões ativas (não finalizadas).
-        
+
         Args:
             deck_id: ID do deck (opcional, para filtrar por deck)
-            
+
         Returns:
             Lista de sessões ativas
-            
+
         Raises:
             RepositoryError: Se houver erro na consulta
         """
         pass
-    
+
     @abstractmethod
     async def find_finished_sessions(self, deck_id: Optional[uuid.UUID] = None) -> List[GenerationSession]:
         """
         Busca sessões finalizadas (concluídas, falhadas ou canceladas).
-        
+
         Args:
             deck_id: ID do deck (opcional, para filtrar por deck)
-            
+
         Returns:
             Lista de sessões finalizadas
-            
+
         Raises:
             RepositoryError: Se houver erro na consulta
         """
         pass
-    
+
     @abstractmethod
     async def find_recent_sessions(self, limit: int = 10, deck_id: Optional[uuid.UUID] = None) -> List[GenerationSession]:
         """
         Busca as sessões mais recentes.
-        
+
         Args:
             limit: Número máximo de sessões a retornar
             deck_id: ID do deck (opcional, para filtrar por deck)
-            
+
         Returns:
             Lista de sessões ordenadas por data de criação (mais recentes primeiro)
-            
+
         Raises:
             RepositoryError: Se houver erro na consulta
         """
         pass
-    
+
     @abstractmethod
     async def update(self, session: GenerationSession) -> GenerationSession:
         """
         Atualiza uma sessão existente.
-        
+
         Args:
             session: Sessão com dados atualizados
-            
+
         Returns:
             Sessão atualizada
-            
+
         Raises:
             RepositoryError: Se houver erro na atualização
             SessionNotFoundError: Se a sessão não existir
         """
         pass
-    
+
     @abstractmethod
     async def delete(self, session_id: uuid.UUID) -> bool:
         """
         Remove uma sessão do banco de dados.
-        
+
         Args:
             session_id: ID da sessão a ser removida
-            
+
         Returns:
             True se a sessão foi removida, False se não foi encontrada
-            
+
         Raises:
             RepositoryError: Se houver erro na remoção
         """
         pass
-    
+
     @abstractmethod
     async def delete_by_deck_id(self, deck_id: uuid.UUID) -> int:
         """
         Remove todas as sessões de um deck.
-        
+
         Args:
             deck_id: ID do deck
-            
+
         Returns:
             Número de sessões removidas
-            
+
         Raises:
             RepositoryError: Se houver erro na remoção
         """
         pass
-    
+
     @abstractmethod
     async def count(self) -> int:
         """
         Conta o total de sessões no banco.
-        
+
         Returns:
             Número total de sessões
-            
+
         Raises:
             RepositoryError: Se houver erro na contagem
         """
         pass
-    
+
     @abstractmethod
     async def count_by_deck_id(self, deck_id: uuid.UUID) -> int:
         """
         Conta o número de sessões de um deck.
-        
+
         Args:
             deck_id: ID do deck
-            
+
         Returns:
             Número de sessões do deck
-            
+
         Raises:
             RepositoryError: Se houver erro na contagem
         """
         pass
-    
+
     @abstractmethod
     async def count_by_status(self, status: GenerationStatus) -> int:
         """
         Conta o número de sessões com um status específico.
-        
+
         Args:
             status: Status das sessões
-            
+
         Returns:
             Número de sessões com o status
-            
+
         Raises:
             RepositoryError: Se houver erro na contagem
         """
         pass
-    
+
     @abstractmethod
     async def exists(self, session_id: uuid.UUID) -> bool:
         """
         Verifica se uma sessão existe.
-        
+
         Args:
             session_id: ID da sessão
-            
+
         Returns:
             True se a sessão existe, False caso contrário
-            
+
         Raises:
             RepositoryError: Se houver erro na verificação
         """
         pass
-    
+
     @abstractmethod
     async def cleanup_old_sessions(self, days_old: int = 30) -> int:
         """
         Remove sessões antigas (para limpeza de dados).
-        
+
         Args:
             days_old: Número de dias para considerar uma sessão como antiga
-            
+
         Returns:
             Número de sessões removidas
-            
+
         Raises:
             RepositoryError: Se houver erro na limpeza
         """

--- a/django/apps/decks/domain/services/__init__.py
+++ b/django/apps/decks/domain/services/__init__.py
@@ -14,10 +14,12 @@ Características dos Serviços de Domínio:
 
 from .duplicate_detection_service import DuplicateDetectionService
 from .card_quality_service import CardQualityService, QualityReport, QualityLevel
+from . import scheduling_service
 
 __all__ = [
     'DuplicateDetectionService',
     'CardQualityService',
     'QualityReport',
-    'QualityLevel'
+    'QualityLevel',
+    'scheduling_service',
 ]

--- a/django/apps/decks/domain/services/card_quality_service.py
+++ b/django/apps/decks/domain/services/card_quality_service.py
@@ -40,7 +40,7 @@ class QualityReport:
 class CardQualityService:
     """
     Serviço para avaliação da qualidade de cards.
-    
+
     Este serviço implementa diferentes critérios de qualidade:
     - Comprimento e complexidade da palavra
     - Qualidade da tradução
@@ -48,7 +48,7 @@ class CardQualityService:
     - Diversidade do vocabulário
     - Clareza e utilidade
     """
-    
+
     # Configurações de qualidade
     MIN_WORD_LENGTH = 3
     MAX_WORD_LENGTH = 50
@@ -56,52 +56,52 @@ class CardQualityService:
     MAX_EXAMPLE_LENGTH = 200
     MIN_TRANSLATION_LENGTH = 2
     MAX_TRANSLATION_LENGTH = 100
-    
+
     # Pesos para cálculo do score
     WORD_WEIGHT = 0.2
     TRANSLATION_WEIGHT = 0.3
     EXAMPLE_WEIGHT = 0.4
     DIVERSITY_WEIGHT = 0.1
-    
+
     def evaluate_card(self, card: Card, context_cards: List[Card] = None) -> QualityReport:
         """
         Avalia a qualidade de um card.
-        
+
         Args:
             card: Card para avaliar
             context_cards: Cards do contexto (para análise de diversidade)
-            
+
         Returns:
             Relatório de qualidade
         """
         issues = []
         suggestions = []
         metrics = {}
-        
+
         # Avalia a palavra
         word_score, word_issues, word_suggestions = self._evaluate_word(card.word.value)
         issues.extend(word_issues)
         suggestions.extend(word_suggestions)
         metrics['word_score'] = word_score
-        
+
         # Avalia a tradução
         translation_score, translation_issues, translation_suggestions = self._evaluate_translation(card.translation.value)
         issues.extend(translation_issues)
         suggestions.extend(translation_suggestions)
         metrics['translation_score'] = translation_score
-        
+
         # Avalia o exemplo
         example_score, example_issues, example_suggestions = self._evaluate_example(card.example.original, card.example.translated)
         issues.extend(example_issues)
         suggestions.extend(example_suggestions)
         metrics['example_score'] = example_score
-        
+
         # Avalia diversidade (se há cards de contexto)
         diversity_score = 1.0
         if context_cards:
             diversity_score = self._evaluate_diversity(card, context_cards)
         metrics['diversity_score'] = diversity_score
-        
+
         # Calcula score geral
         overall_score = (
             word_score * self.WORD_WEIGHT +
@@ -109,10 +109,10 @@ class CardQualityService:
             example_score * self.EXAMPLE_WEIGHT +
             diversity_score * self.DIVERSITY_WEIGHT
         )
-        
+
         # Determina nível de qualidade
         quality_level = self._determine_quality_level(overall_score, issues)
-        
+
         return QualityReport(
             card=card,
             overall_score=overall_score,
@@ -121,23 +121,23 @@ class CardQualityService:
             suggestions=suggestions,
             metrics=metrics
         )
-    
+
     def _evaluate_word(self, word: str) -> Tuple[float, List[str], List[str]]:
         """
         Avalia a qualidade da palavra.
-        
+
         Args:
             word: Palavra para avaliar
-            
+
         Returns:
             Tupla (score, issues, suggestions)
         """
         issues = []
         suggestions = []
         score = 1.0
-        
+
         word_length = len(word)
-        
+
         # Verifica comprimento
         if word_length < self.MIN_WORD_LENGTH:
             issues.append(f"Palavra muito curta ({word_length} caracteres)")
@@ -145,44 +145,44 @@ class CardQualityService:
         elif word_length > self.MAX_WORD_LENGTH:
             issues.append(f"Palavra muito longa ({word_length} caracteres)")
             score -= 0.2
-        
+
         # Verifica se contém apenas letras e espaços
         if not word.replace(' ', '').isalpha():
             issues.append("Palavra contém caracteres inválidos")
             score -= 0.4
-        
+
         # Verifica se é muito comum (palavras muito básicas)
         common_words = {'the', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for', 'of', 'with', 'by'}
         if word.lower() in common_words:
             issues.append("Palavra muito comum, considere algo mais específico")
             suggestions.append("Use palavras mais específicas e úteis para aprendizado")
             score -= 0.2
-        
+
         # Verifica se é uma palavra única (não frase muito longa)
         word_count = len(word.split())
         if word_count > 5:
             issues.append("Frase muito longa, considere usar uma palavra ou frase mais curta")
             suggestions.append("Mantenha foco em uma palavra ou frase curta")
             score -= 0.3
-        
+
         return max(0.0, min(1.0, score)), issues, suggestions
-    
+
     def _evaluate_translation(self, translation: str) -> Tuple[float, List[str], List[str]]:
         """
         Avalia a qualidade da tradução.
-        
+
         Args:
             translation: Tradução para avaliar
-            
+
         Returns:
             Tupla (score, issues, suggestions)
         """
         issues = []
         suggestions = []
         score = 1.0
-        
+
         translation_length = len(translation)
-        
+
         # Verifica comprimento
         if translation_length < self.MIN_TRANSLATION_LENGTH:
             issues.append(f"Tradução muito curta ({translation_length} caracteres)")
@@ -190,44 +190,44 @@ class CardQualityService:
         elif translation_length > self.MAX_TRANSLATION_LENGTH:
             issues.append(f"Tradução muito longa ({translation_length} caracteres)")
             score -= 0.2
-        
+
         # Verifica se contém apenas caracteres válidos
         if not translation.replace(' ', '').replace(',', '').replace(';', '').replace('(', '').replace(')', '').isalpha():
             issues.append("Tradução contém caracteres inválidos")
             score -= 0.3
-        
+
         # Verifica se tem múltiplas traduções (isso é bom)
         if ',' in translation or ';' in translation:
             score += 0.1
             suggestions.append("Boa! Múltiplas traduções aumentam o valor do card")
-        
+
         # Verifica se é muito genérica
         generic_translations = {'coisa', 'algo', 'item', 'objeto', 'elemento'}
         if any(gen in translation.lower() for gen in generic_translations):
             issues.append("Tradução muito genérica")
             suggestions.append("Use traduções mais específicas e precisas")
             score -= 0.2
-        
+
         return max(0.0, min(1.0, score)), issues, suggestions
-    
+
     def _evaluate_example(self, original: str, translated: str) -> Tuple[float, List[str], List[str]]:
         """
         Avalia a qualidade do exemplo.
-        
+
         Args:
             original: Frase original em inglês
             translated: Tradução da frase
-            
+
         Returns:
             Tupla (score, issues, suggestions)
         """
         issues = []
         suggestions = []
         score = 1.0
-        
+
         original_length = len(original)
         translated_length = len(translated)
-        
+
         # Verifica comprimento da frase original
         if original_length < self.MIN_EXAMPLE_LENGTH:
             issues.append(f"Exemplo muito curto ({original_length} caracteres)")
@@ -235,12 +235,12 @@ class CardQualityService:
         elif original_length > self.MAX_EXAMPLE_LENGTH:
             issues.append(f"Exemplo muito longo ({original_length} caracteres)")
             score -= 0.2
-        
+
         # Verifica comprimento da tradução
         if translated_length < self.MIN_EXAMPLE_LENGTH:
             issues.append(f"Tradução do exemplo muito curta ({translated_length} caracteres)")
             score -= 0.3
-        
+
         # Verifica se o exemplo é muito genérico
         generic_examples = [
             "this is a", "that is a", "it is a", "here is a", "there is a"
@@ -249,34 +249,34 @@ class CardQualityService:
             issues.append("Exemplo muito genérico")
             suggestions.append("Use exemplos mais específicos e contextualizados")
             score -= 0.3
-        
+
         # Verifica se o exemplo contém a palavra
         words_in_example = original.lower().split()
         if len(words_in_example) > 0:
             # Verifica se pelo menos uma palavra do exemplo é relevante
             # (isso seria melhorado com análise mais sofisticada)
             score += 0.1
-        
+
         return max(0.0, min(1.0, score)), issues, suggestions
-    
+
     def _evaluate_diversity(self, card: Card, context_cards: List[Card]) -> float:
         """
         Avalia a diversidade do card em relação aos cards de contexto.
-        
+
         Args:
             card: Card para avaliar
             context_cards: Cards do contexto
-            
+
         Returns:
             Score de diversidade (0.0 a 1.0)
         """
         if not context_cards:
             return 1.0
-        
+
         # Verifica similaridade com outros cards
         similar_count = 0
         total_cards = len(context_cards)
-        
+
         for context_card in context_cards:
             # Verifica se as palavras são muito similares
             if card.word.normalized == context_card.word.normalized:
@@ -284,20 +284,20 @@ class CardQualityService:
             # Verifica se as traduções são muito similares
             elif card.translation.normalized == context_card.translation.normalized:
                 similar_count += 1
-        
+
         # Calcula score de diversidade
         diversity_ratio = 1.0 - (similar_count / total_cards)
-        
+
         return max(0.0, min(1.0, diversity_ratio))
-    
+
     def _determine_quality_level(self, score: float, issues: List[str]) -> QualityLevel:
         """
         Determina o nível de qualidade baseado no score e issues.
-        
+
         Args:
             score: Score geral de qualidade
             issues: Lista de problemas encontrados
-            
+
         Returns:
             Nível de qualidade
         """
@@ -311,47 +311,47 @@ class CardQualityService:
             return QualityLevel.POOR
         else:
             return QualityLevel.INVALID
-    
+
     def batch_evaluate(self, cards: List[Card]) -> List[QualityReport]:
         """
         Avalia múltiplos cards em lote.
-        
+
         Args:
             cards: Lista de cards para avaliar
-            
+
         Returns:
             Lista de relatórios de qualidade
         """
         reports = []
-        
+
         for i, card in enumerate(cards):
             # Usa os outros cards como contexto
             context_cards = cards[:i] + cards[i+1:]
             report = self.evaluate_card(card, context_cards)
             reports.append(report)
-        
+
         return reports
-    
+
     def get_quality_statistics(self, reports: List[QualityReport]) -> Dict[str, any]:
         """
         Gera estatísticas de qualidade para uma lista de relatórios.
-        
+
         Args:
             reports: Lista de relatórios de qualidade
-            
+
         Returns:
             Dicionário com estatísticas
         """
         if not reports:
             return {}
-        
+
         total_cards = len(reports)
         scores = [report.overall_score for report in reports]
-        
+
         quality_levels = {}
         for level in QualityLevel:
             quality_levels[level.value] = len([r for r in reports if r.quality_level == level])
-        
+
         return {
             'total_cards': total_cards,
             'average_score': sum(scores) / len(scores),

--- a/django/apps/decks/domain/services/duplicate_detection_service.py
+++ b/django/apps/decks/domain/services/duplicate_detection_service.py
@@ -17,203 +17,208 @@ from ..repositories.icard_repository import ICardRepository
 class DuplicateDetectionService:
     """
     Serviço para detecção de duplicatas entre cards.
-    
+
     Este serviço implementa diferentes estratégias para detectar cards similares:
     - Comparação exata de palavras
     - Similaridade textual (difflib)
     - Análise de contexto
     - Verificação de traduções similares
     """
-    
+
     def __init__(self, card_repository: ICardRepository):
         """
         Inicializa o serviço com o repositório de cards.
-        
+
         Args:
             card_repository: Repositório para buscar cards existentes
         """
         self.card_repository = card_repository
-    
+
     async def find_duplicates_for_card(self, card: Card, similarity_threshold: float = 0.8) -> List[Tuple[Card, float]]:
         """
-        Busca cards duplicados ou similares para um card específico.
-        
+        Busca cards duplicados ou similares para um card específico, dentro
+        do mesmo owner (isolamento multi-tenant — card.owner_id já identifica
+        o dono, ver D1 em openspec/changes/sprint-2-decks-cards/design.md).
+
         Args:
             card: Card para verificar duplicatas
             similarity_threshold: Limiar de similaridade (0.0 a 1.0)
-            
+
         Returns:
             Lista de tuplas (card_duplicado, score_similaridade)
         """
         duplicates = []
-        
+
         # Busca cards existentes no mesmo deck
         if card.deck_id:
-            existing_cards = await self.card_repository.find_by_deck_id(card.deck_id)
+            existing_cards = await self.card_repository.find_by_deck_id(card.deck_id, card.owner_id)
         else:
-            # Se não tem deck_id, busca todos os cards
-            existing_cards = await self._get_all_cards()
-        
+            # Se não tem deck_id, busca todos os cards do mesmo owner
+            existing_cards = await self._get_all_cards(card.owner_id)
+
         for existing_card in existing_cards:
             # Não compara com o próprio card
             if existing_card.id == card.id:
                 continue
-            
+
             similarity_score = self._calculate_similarity(card, existing_card)
-            
+
             if similarity_score >= similarity_threshold:
                 duplicates.append((existing_card, similarity_score))
-        
+
         # Ordena por score de similaridade (maior primeiro)
         duplicates.sort(key=lambda x: x[1], reverse=True)
-        
+
         return duplicates
-    
-    async def find_exact_duplicates(self, word: str, deck_id: str = None) -> List[Card]:
+
+    async def find_exact_duplicates(self, word: str, owner_id: str, deck_id: str = None) -> List[Card]:
         """
-        Busca duplicatas exatas de uma palavra.
-        
+        Busca duplicatas exatas de uma palavra, dentro do owner especificado.
+
         Args:
             word: Palavra para verificar
+            owner_id: dono dos cards (isolamento multi-tenant)
             deck_id: ID do deck (opcional)
-            
+
         Returns:
             Lista de cards com a mesma palavra
         """
-        return await self.card_repository.find_by_word(word)
-    
-    async def find_similar_words(self, word: str, similarity_threshold: float = 0.7) -> List[Tuple[Card, float]]:
+        return await self.card_repository.find_by_word(word, owner_id)
+
+    async def find_similar_words(self, word: str, owner_id: str, similarity_threshold: float = 0.7) -> List[Tuple[Card, float]]:
         """
-        Busca palavras similares usando algoritmos de similaridade.
-        
+        Busca palavras similares usando algoritmos de similaridade, dentro
+        do owner especificado.
+
         Args:
             word: Palavra para comparar
+            owner_id: dono dos cards (isolamento multi-tenant)
             similarity_threshold: Limiar de similaridade
-            
+
         Returns:
             Lista de tuplas (card, score_similaridade)
         """
-        all_cards = await self._get_all_cards()
+        all_cards = await self._get_all_cards(owner_id)
         similar_cards = []
-        
+
         word_normalized = word.lower().strip()
-        
+
         for card in all_cards:
             card_word_normalized = card.word.normalized
-            
+
             # Calcula similaridade usando difflib
             similarity = SequenceMatcher(None, word_normalized, card_word_normalized).ratio()
-            
+
             if similarity >= similarity_threshold:
                 similar_cards.append((card, similarity))
-        
+
         # Ordena por score de similaridade
         similar_cards.sort(key=lambda x: x[1], reverse=True)
-        
+
         return similar_cards
-    
+
     def _calculate_similarity(self, card1: Card, card2: Card) -> float:
         """
         Calcula a similaridade entre dois cards.
-        
+
         Usa múltiplos critérios:
         - Similaridade da palavra (peso 0.6)
         - Similaridade da tradução (peso 0.3)
         - Similaridade do exemplo (peso 0.1)
-        
+
         Args:
             card1: Primeiro card
             card2: Segundo card
-            
+
         Returns:
             Score de similaridade (0.0 a 1.0)
         """
         # Similaridade da palavra
         word_similarity = SequenceMatcher(
-            None, 
-            card1.word.normalized, 
+            None,
+            card1.word.normalized,
             card2.word.normalized
         ).ratio()
-        
+
         # Similaridade da tradução
         translation_similarity = SequenceMatcher(
             None,
             card1.translation.normalized,
             card2.translation.normalized
         ).ratio()
-        
+
         # Similaridade do exemplo
         example_similarity = SequenceMatcher(
             None,
             card1.example.original_normalized,
             card2.example.original_normalized
         ).ratio()
-        
+
         # Calcula score ponderado
         weighted_score = (
             word_similarity * 0.6 +
             translation_similarity * 0.3 +
             example_similarity * 0.1
         )
-        
+
         return weighted_score
-    
+
     def _normalize_text(self, text: str) -> str:
         """
         Normaliza texto para comparação.
-        
+
         Args:
             text: Texto para normalizar
-            
+
         Returns:
             Texto normalizado
         """
         if not text:
             return ""
-        
+
         # Converte para lowercase
         normalized = text.lower()
-        
+
         # Remove pontuação
         normalized = re.sub(r'[^\w\s]', '', normalized)
-        
+
         # Remove espaços múltiplos
         normalized = re.sub(r'\s+', ' ', normalized)
-        
+
         return normalized.strip()
-    
+
     def are_translations_similar(self, translation1: str, translation2: str, threshold: float = 0.8) -> bool:
         """
         Verifica se duas traduções são similares.
-        
+
         Args:
             translation1: Primeira tradução
             translation2: Segunda tradução
             threshold: Limiar de similaridade
-            
+
         Returns:
             True se as traduções são similares
         """
         norm1 = self._normalize_text(translation1)
         norm2 = self._normalize_text(translation2)
-        
+
         similarity = SequenceMatcher(None, norm1, norm2).ratio()
-        
+
         return similarity >= threshold
-    
+
     def suggest_alternatives(self, word: str, existing_cards: List[Card]) -> List[str]:
         """
         Sugere alternativas para uma palavra que pode ser duplicada.
-        
+
         Args:
             word: Palavra original
             existing_cards: Cards existentes similares
-            
+
         Returns:
             Lista de sugestões alternativas
         """
         suggestions = []
-        
+
         # Se é uma palavra simples, sugere variações
         if len(word.split()) == 1:
             # Adiciona sufixos comuns
@@ -221,13 +226,13 @@ class DuplicateDetectionService:
             for suffix in suffixes:
                 if not word.endswith(suffix):
                     suggestions.append(f"{word}{suffix}")
-            
+
             # Adiciona prefixos comuns
             prefixes = ['un', 're', 'pre', 'mis']
             for prefix in prefixes:
                 if not word.startswith(prefix):
                     suggestions.append(f"{prefix}{word}")
-        
+
         # Sugere frases relacionadas baseadas nos cards existentes
         for card in existing_cards:
             if card.example.word_count > 1:
@@ -236,52 +241,53 @@ class DuplicateDetectionService:
                 for example_word in example_words:
                     if example_word.lower() != word.lower() and len(example_word) > 3:
                         suggestions.append(example_word)
-        
+
         # Remove duplicatas e limita a 5 sugestões
         unique_suggestions = list(set(suggestions))[:5]
-        
+
         return unique_suggestions
-    
-    async def _get_all_cards(self) -> List[Card]:
+
+    async def _get_all_cards(self, owner_id: str) -> List[Card]:
         """
-        Busca todos os cards do repositório.
-        
+        Busca todos os cards do owner especificado.
+
         Returns:
-            Lista de todos os cards
+            Lista de todos os cards do owner
         """
-        # Como não temos um método find_all no repositório, vamos simular
-        # Em uma implementação real, seria necessário adicionar esse método
-        # Por enquanto, retornamos lista vazia
+        # ICardRepository não tem um "find_all" genérico (só buscas
+        # filtradas por deck/palavra/contexto/due) — mantido como no-op,
+        # como já era antes desta sprint; nada no domínio chama este caminho
+        # sem deck_id hoje.
         return []
-    
+
     def validate_card_uniqueness(self, card: Card, existing_cards: List[Card]) -> Tuple[bool, List[str]]:
         """
         Valida se um card é único comparado com cards existentes.
-        
+
         Args:
             card: Card para validar
             existing_cards: Lista de cards existentes
-            
+
         Returns:
             Tupla (é_único, lista_de_problemas)
         """
         problems = []
-        
+
         for existing_card in existing_cards:
             # Verifica duplicata exata
             if card.word.normalized == existing_card.word.normalized:
                 problems.append(f"Palavra '{card.word.value}' já existe no card {existing_card.id}")
                 continue
-            
+
             # Verifica similaridade alta
             similarity = self._calculate_similarity(card, existing_card)
             if similarity > 0.9:
                 problems.append(f"Card muito similar (similaridade: {similarity:.2f}) ao card {existing_card.id}")
-            
+
             # Verifica traduções muito similares
             if self.are_translations_similar(card.translation.value, existing_card.translation.value):
                 problems.append(f"Tradução muito similar ao card {existing_card.id}")
-        
+
         is_unique = len(problems) == 0
-        
+
         return is_unique, problems

--- a/django/apps/decks/domain/services/scheduling_service.py
+++ b/django/apps/decks/domain/services/scheduling_service.py
@@ -1,0 +1,60 @@
+"""
+Serviço de agendamento de repetição espaçada via FSRS.
+
+Encapsula o pacote `fsrs` (ver D4 em
+openspec/changes/sprint-2-decks-cards/design.md): nenhum outro módulo do
+domínio importa `fsrs` diretamente — se o algoritmo for trocado no futuro,
+a mudança fica isolada aqui.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import fsrs
+
+from ..entities.card import Card
+from ..exceptions import DomainValidationError
+
+_scheduler = fsrs.Scheduler()
+
+_RATING_MAP = {
+    "again": fsrs.Rating.Again,
+    "hard": fsrs.Rating.Hard,
+    "good": fsrs.Rating.Good,
+    "easy": fsrs.Rating.Easy,
+}
+
+
+def review_card(card: Card, rating: str, reviewed_at: Optional[datetime] = None) -> Card:
+    """
+    Aplica uma revisão ao card, recalculando seus campos de agendamento FSRS
+    em memória (não persiste — quem chama decide quando salvar via
+    repositório).
+    """
+    if rating not in _RATING_MAP:
+        raise DomainValidationError(f"Invalid rating: {rating!r}. Must be one of {sorted(_RATING_MAP)}")
+
+    reviewed_at = reviewed_at or datetime.now(timezone.utc)
+
+    fsrs_card = fsrs.Card(
+        state=fsrs.State(card.fsrs_state),
+        step=card.fsrs_step,
+        stability=card.stability,
+        difficulty=card.difficulty,
+        due=card.due_at,
+        last_review=card.last_reviewed_at,
+    )
+
+    updated_fsrs_card, _review_log = _scheduler.review_card(
+        fsrs_card, _RATING_MAP[rating], review_datetime=reviewed_at
+    )
+
+    card.fsrs_state = int(updated_fsrs_card.state)
+    card.fsrs_step = updated_fsrs_card.step
+    card.stability = updated_fsrs_card.stability
+    card.difficulty = updated_fsrs_card.difficulty
+    card.due_at = updated_fsrs_card.due
+    card.last_reviewed_at = updated_fsrs_card.last_review
+    card.updated_at = datetime.now(timezone.utc)
+
+    return card

--- a/django/apps/decks/domain/value_objects/__init__.py
+++ b/django/apps/decks/domain/value_objects/__init__.py
@@ -18,7 +18,7 @@ from .audio_path import AudioPath
 
 __all__ = [
     'Word',
-    'Translation', 
+    'Translation',
     'Example',
     'AudioPath'
 ]

--- a/django/apps/decks/domain/value_objects/audio_path.py
+++ b/django/apps/decks/domain/value_objects/audio_path.py
@@ -12,83 +12,84 @@ import os
 from dataclasses import dataclass
 from typing import Optional
 from pathlib import Path
+from ..exceptions import DomainValidationError
 
 
 @dataclass(frozen=True)
 class AudioPath:
     """
     Objeto de valor que representa o caminho para um arquivo de áudio.
-    
+
     Características:
     - Imutável (frozen=True)
     - Validado na criação
     - Suporta diferentes formatos
     """
-    
+
     path: str
-    
+
     # Formatos de áudio suportados
     SUPPORTED_FORMATS = {'.mp3', '.wav', '.ogg', '.m4a'}
-    
+
     def __post_init__(self):
         """
         Valida o caminho do áudio após a criação.
         """
         if not self.path or not self.path.strip():
-            raise ValueError("Audio path cannot be empty")
-        
+            raise DomainValidationError("Audio path cannot be empty")
+
         # Normaliza o caminho
         normalized_path = self.path.strip()
-        
+
         # Converte para Path para validação
         path_obj = Path(normalized_path)
-        
+
         # Verifica se tem extensão
         if not path_obj.suffix:
-            raise ValueError("Audio path must have a file extension")
-        
+            raise DomainValidationError("Audio path must have a file extension")
+
         # Verifica se a extensão é suportada
         if path_obj.suffix.lower() not in self.SUPPORTED_FORMATS:
-            raise ValueError(f"Audio format {path_obj.suffix} is not supported. Supported formats: {self.SUPPORTED_FORMATS}")
-        
+            raise DomainValidationError(f"Audio format {path_obj.suffix} is not supported. Supported formats: {self.SUPPORTED_FORMATS}")
+
         # Define o caminho normalizado
         object.__setattr__(self, 'path', str(path_obj))
-    
+
     @property
     def filename(self) -> str:
         """
         Retorna apenas o nome do arquivo.
         """
         return Path(self.path).name
-    
+
     @property
     def directory(self) -> str:
         """
         Retorna o diretório do arquivo.
         """
         return str(Path(self.path).parent)
-    
+
     @property
     def extension(self) -> str:
         """
         Retorna a extensão do arquivo.
         """
         return Path(self.path).suffix.lower()
-    
+
     @property
     def stem(self) -> str:
         """
         Retorna o nome do arquivo sem a extensão.
         """
         return Path(self.path).stem
-    
+
     @property
     def exists(self) -> bool:
         """
         Verifica se o arquivo existe no sistema de arquivos.
         """
         return Path(self.path).exists()
-    
+
     @property
     def size_bytes(self) -> Optional[int]:
         """
@@ -97,39 +98,39 @@ class AudioPath:
         if self.exists:
             return Path(self.path).stat().st_size
         return None
-    
+
     def is_mp3(self) -> bool:
         """
         Verifica se o arquivo é MP3.
         """
         return self.extension == '.mp3'
-    
+
     def is_wav(self) -> bool:
         """
         Verifica se o arquivo é WAV.
         """
         return self.extension == '.wav'
-    
+
     def is_ogg(self) -> bool:
         """
         Verifica se o arquivo é OGG.
         """
         return self.extension == '.ogg'
-    
+
     def is_m4a(self) -> bool:
         """
         Verifica se o arquivo é M4A.
         """
         return self.extension == '.m4a'
-    
+
     def to_anki_format(self) -> str:
         """
         Converte o caminho para o formato usado pelo Anki.
-        
+
         O Anki espera o caminho no formato: [sound:filename.ext]
         """
         return f"[sound:{self.filename}]"
-    
+
     def to_dict(self) -> dict:
         """
         Converte para dicionário para serialização.
@@ -143,23 +144,23 @@ class AudioPath:
             "exists": self.exists,
             "size_bytes": self.size_bytes
         }
-    
+
     @classmethod
     def from_dict(cls, data: dict) -> 'AudioPath':
         """
         Cria um AudioPath a partir de um dicionário.
         """
         return cls(path=data["path"])
-    
+
     @classmethod
     def create_from_filename(cls, filename: str, directory: str = "") -> 'AudioPath':
         """
         Cria um AudioPath a partir de um nome de arquivo e diretório.
-        
+
         Args:
             filename: Nome do arquivo (com extensão)
             directory: Diretório (opcional)
-            
+
         Returns:
             AudioPath criado
         """
@@ -167,15 +168,15 @@ class AudioPath:
             full_path = os.path.join(directory, filename)
         else:
             full_path = filename
-        
+
         return cls(path=full_path)
-    
+
     def __str__(self) -> str:
         return self.path
-    
+
     def __repr__(self) -> str:
         return f"AudioPath('{self.path}')"
-    
+
     def __eq__(self, other) -> bool:
         """
         Comparação baseada no caminho normalizado.
@@ -183,7 +184,7 @@ class AudioPath:
         if not isinstance(other, AudioPath):
             return False
         return self.path == other.path
-    
+
     def __hash__(self) -> int:
         """
         Hash baseado no caminho.

--- a/django/apps/decks/domain/value_objects/example.py
+++ b/django/apps/decks/domain/value_objects/example.py
@@ -11,127 +11,128 @@ Características:
 from dataclasses import dataclass
 import re
 from typing import Optional
+from ..exceptions import DomainValidationError
 
 
 @dataclass(frozen=True)
 class Example:
     """
     Objeto de valor que representa um exemplo de uso da palavra.
-    
+
     Características:
     - Imutável (frozen=True)
     - Contém frase original e tradução
     - Validado na criação
     """
-    
+
     original: str
     translated: str
-    
+
     def __post_init__(self):
         """
         Valida e normaliza o exemplo após a criação.
         """
         if not self.original or not self.original.strip():
-            raise ValueError("Original example cannot be empty")
-        
+            raise DomainValidationError("Original example cannot be empty")
+
         if not self.translated or not self.translated.strip():
-            raise ValueError("Translated example cannot be empty")
-        
+            raise DomainValidationError("Translated example cannot be empty")
+
         # Normaliza as frases
         original_normalized = self.original.strip()
         translated_normalized = self.translated.strip()
-        
+
         # Remove espaços múltiplos
         original_normalized = re.sub(r'\s+', ' ', original_normalized)
         translated_normalized = re.sub(r'\s+', ' ', translated_normalized)
-        
+
         # Valida comprimento mínimo
         if len(original_normalized) < 10:
-            raise ValueError("Original example must have at least 10 characters")
-        
+            raise DomainValidationError("Original example must have at least 10 characters")
+
         if len(translated_normalized) < 10:
-            raise ValueError("Translated example must have at least 10 characters")
-        
+            raise DomainValidationError("Translated example must have at least 10 characters")
+
         # Define os valores normalizados
         object.__setattr__(self, 'original', original_normalized)
         object.__setattr__(self, 'translated', translated_normalized)
-    
+
     @property
     def original_normalized(self) -> str:
         """
         Retorna a versão normalizada da frase original.
         """
         return self.original.lower().strip()
-    
+
     @property
     def translated_normalized(self) -> str:
         """
         Retorna a versão normalizada da tradução.
         """
         return self.translated.lower().strip()
-    
+
     @property
     def word_count_original(self) -> int:
         """
         Retorna o número de palavras na frase original.
         """
         return len(self.original.split())
-    
+
     @property
     def word_count_translated(self) -> int:
         """
         Retorna o número de palavras na tradução.
         """
         return len(self.translated.split())
-    
+
     @property
     def length_original(self) -> int:
         """
         Retorna o comprimento da frase original.
         """
         return len(self.original)
-    
+
     @property
     def length_translated(self) -> int:
         """
         Retorna o comprimento da tradução.
         """
         return len(self.translated)
-    
+
     def contains_word(self, word: str) -> bool:
         """
         Verifica se a frase original contém a palavra especificada.
-        
+
         Args:
             word: Palavra a ser pesquisada
-            
+
         Returns:
             True se a frase contém a palavra
         """
         return word.lower() in self.original_normalized
-    
+
     def highlight_word(self, word: str, highlight_start: str = "**", highlight_end: str = "**") -> str:
         """
         Destaca a palavra na frase original.
-        
+
         Args:
             word: Palavra a ser destacada
             highlight_start: Marcador de início
             highlight_end: Marcador de fim
-            
+
         Returns:
             Frase com a palavra destacada
         """
         import re
-        
+
         # Regex para encontrar a palavra (case insensitive)
         pattern = re.compile(re.escape(word), re.IGNORECASE)
-        
+
         def replace_word(match):
             return f"{highlight_start}{match.group()}{highlight_end}"
-        
+
         return pattern.sub(replace_word, self.original)
-    
+
     def to_dict(self) -> dict:
         """
         Converte para dicionário para serialização.
@@ -146,7 +147,7 @@ class Example:
             "length_original": self.length_original,
             "length_translated": self.length_translated
         }
-    
+
     @classmethod
     def from_dict(cls, data: dict) -> 'Example':
         """
@@ -156,13 +157,13 @@ class Example:
             original=data["original"],
             translated=data["translated"]
         )
-    
+
     def __str__(self) -> str:
         return f"Original: {self.original} | Translated: {self.translated}"
-    
+
     def __repr__(self) -> str:
         return f"Example(original='{self.original[:30]}...', translated='{self.translated[:30]}...')"
-    
+
     def __eq__(self, other) -> bool:
         """
         Comparação baseada nos valores normalizados.
@@ -173,7 +174,7 @@ class Example:
             self.original_normalized == other.original_normalized and
             self.translated_normalized == other.translated_normalized
         )
-    
+
     def __hash__(self) -> int:
         """
         Hash baseado nos valores normalizados.

--- a/django/apps/decks/domain/value_objects/translation.py
+++ b/django/apps/decks/domain/value_objects/translation.py
@@ -11,44 +11,45 @@ Características:
 from dataclasses import dataclass
 import re
 from typing import List
+from ..exceptions import DomainValidationError
 
 
 @dataclass(frozen=True)
 class Translation:
     """
     Objeto de valor que representa uma tradução em português.
-    
+
     Características:
     - Imutável (frozen=True)
     - Validado na criação
     - Suporta múltiplas traduções
     """
-    
+
     value: str
-    
+
     def __post_init__(self):
         """
         Valida e normaliza a tradução após a criação.
         """
         if not self.value or not self.value.strip():
-            raise ValueError("Translation cannot be empty")
-        
+            raise DomainValidationError("Translation cannot be empty")
+
         # Remove espaços extras e normaliza
         normalized_value = self.value.strip()
-        
+
         # Remove espaços múltiplos
         normalized_value = re.sub(r'\s+', ' ', normalized_value)
-        
+
         # Define o valor normalizado
         object.__setattr__(self, 'value', normalized_value)
-    
+
     @property
     def normalized(self) -> str:
         """
         Retorna a versão normalizada da tradução (lowercase, sem espaços extras).
         """
         return self.value.lower().strip()
-    
+
     @property
     def translations_list(self) -> List[str]:
         """
@@ -56,7 +57,7 @@ class Translation:
         Separa por vírgula e remove espaços extras.
         """
         return [t.strip() for t in self.value.split(',') if t.strip()]
-    
+
     @property
     def primary_translation(self) -> str:
         """
@@ -64,7 +65,7 @@ class Translation:
         """
         translations = self.translations_list
         return translations[0] if translations else self.value
-    
+
     @property
     def alternative_translations(self) -> List[str]:
         """
@@ -72,28 +73,28 @@ class Translation:
         """
         translations = self.translations_list
         return translations[1:] if len(translations) > 1 else []
-    
+
     @property
     def has_alternatives(self) -> bool:
         """
         Verifica se há traduções alternativas.
         """
         return len(self.translations_list) > 1
-    
+
     @property
     def translation_count(self) -> int:
         """
         Retorna o número de traduções disponíveis.
         """
         return len(self.translations_list)
-    
+
     def contains_translation(self, search_term: str) -> bool:
         """
         Verifica se alguma das traduções contém o termo pesquisado.
-        
+
         Args:
             search_term: Termo a ser pesquisado
-            
+
         Returns:
             True se alguma tradução contém o termo
         """
@@ -102,7 +103,7 @@ class Translation:
             search_lower in translation.lower()
             for translation in self.translations_list
         )
-    
+
     def to_dict(self) -> dict:
         """
         Converte para dicionário para serialização.
@@ -115,20 +116,20 @@ class Translation:
             "alternative_translations": self.alternative_translations,
             "translation_count": self.translation_count
         }
-    
+
     @classmethod
     def from_dict(cls, data: dict) -> 'Translation':
         """
         Cria um Translation a partir de um dicionário.
         """
         return cls(value=data["value"])
-    
+
     def __str__(self) -> str:
         return self.value
-    
+
     def __repr__(self) -> str:
         return f"Translation('{self.value}')"
-    
+
     def __eq__(self, other) -> bool:
         """
         Comparação baseada no valor normalizado.
@@ -136,7 +137,7 @@ class Translation:
         if not isinstance(other, Translation):
             return False
         return self.normalized == other.normalized
-    
+
     def __hash__(self) -> int:
         """
         Hash baseado no valor normalizado.

--- a/django/apps/decks/domain/value_objects/word.py
+++ b/django/apps/decks/domain/value_objects/word.py
@@ -16,75 +16,76 @@ No caso de Word:
 from dataclasses import dataclass
 import re
 from typing import Optional
+from ..exceptions import DomainValidationError
 
 
 @dataclass(frozen=True)  # frozen=True torna o objeto imutável
 class Word:
     """
     Objeto de valor que representa uma palavra em inglês.
-    
+
     Características:
     - Imutável (frozen=True)
     - Validado na criação
     - Normalizado para comparações
     """
-    
+
     value: str
-    
+
     def __post_init__(self):
         """
         Valida e normaliza a palavra após a criação.
         Como o objeto é frozen, usamos object.__setattr__ para modificar.
         """
         if not self.value or not self.value.strip():
-            raise ValueError("Word cannot be empty")
-        
+            raise DomainValidationError("Word cannot be empty")
+
         # Remove espaços extras e normaliza
         normalized_value = self.value.strip()
-        
+
         # Valida se contém apenas letras, espaços e hífens
         if not re.match(r'^[a-zA-Z\s\-]+$', normalized_value):
-            raise ValueError("Word can only contain letters, spaces and hyphens")
-        
+            raise DomainValidationError("Word can only contain letters, spaces and hyphens")
+
         # Remove espaços múltiplos
         normalized_value = re.sub(r'\s+', ' ', normalized_value)
-        
+
         # Define o valor normalizado
         object.__setattr__(self, 'value', normalized_value)
-    
+
     @property
     def normalized(self) -> str:
         """
         Retorna a versão normalizada da palavra (lowercase, sem espaços extras).
         """
         return self.value.lower().strip()
-    
+
     @property
     def length(self) -> int:
         """
         Retorna o comprimento da palavra.
         """
         return len(self.value)
-    
+
     @property
     def word_count(self) -> int:
         """
         Retorna o número de palavras (para frases).
         """
         return len(self.value.split())
-    
+
     def is_single_word(self) -> bool:
         """
         Verifica se é uma única palavra (não uma frase).
         """
         return self.word_count == 1
-    
+
     def is_phrase(self) -> bool:
         """
         Verifica se é uma frase (múltiplas palavras).
         """
         return self.word_count > 1
-    
+
     def starts_with_vowel(self) -> bool:
         """
         Verifica se a palavra começa com vogal.
@@ -92,10 +93,10 @@ class Word:
         """
         if not self.is_single_word():
             return False
-        
+
         first_letter = self.value.lower()[0]
         return first_letter in 'aeiou'
-    
+
     def to_dict(self) -> dict:
         """
         Converte para dicionário para serialização.
@@ -106,20 +107,20 @@ class Word:
             "length": self.length,
             "word_count": self.word_count
         }
-    
+
     @classmethod
     def from_dict(cls, data: dict) -> 'Word':
         """
         Cria um Word a partir de um dicionário.
         """
         return cls(value=data["value"])
-    
+
     def __str__(self) -> str:
         return self.value
-    
+
     def __repr__(self) -> str:
         return f"Word('{self.value}')"
-    
+
     def __eq__(self, other) -> bool:
         """
         Comparação baseada no valor normalizado.
@@ -127,7 +128,7 @@ class Word:
         if not isinstance(other, Word):
             return False
         return self.normalized == other.normalized
-    
+
     def __hash__(self) -> int:
         """
         Hash baseado no valor normalizado.

--- a/django/apps/decks/infrastructure/exceptions.py
+++ b/django/apps/decks/infrastructure/exceptions.py
@@ -1,0 +1,50 @@
+"""
+Exceções da camada de infraestrutura (Mongo). Antes desta sprint,
+`RepositoryError` e as exceções de "não encontrado" viviam soltas dentro
+de `card_repository.py`, e todo outro módulo de repositório importava
+delas como se fosse um módulo compartilhado — layering estranho (infra
+importando de um "irmão" de infra). Agora moram todas aqui, um único
+lugar, todas descendentes de `AppError` (core/exceptions.py).
+"""
+
+from core.exceptions import AppError
+
+
+class InfrastructureError(AppError):
+    """Base para qualquer falha da camada de infraestrutura (Mongo, etc.)."""
+
+    code = "infrastructure_error"
+
+
+class RepositoryError(InfrastructureError):
+    """Falha genérica de persistência/consulta num repositório Mongo."""
+
+    code = "repository_error"
+
+
+class CardNotFoundError(RepositoryError):
+    code = "card_not_found"
+
+
+class DeckNotFoundError(RepositoryError):
+    code = "deck_not_found"
+
+
+class CategoryNotFoundError(RepositoryError):
+    code = "category_not_found"
+
+
+class SessionNotFoundError(RepositoryError):
+    code = "session_not_found"
+
+
+class MongoNotConnectedError(InfrastructureError):
+    """Uma operação foi tentada antes de `MongoDBConnectionManager.connect()`."""
+
+    code = "mongodb_not_connected"
+
+
+class MongoConfigError(InfrastructureError):
+    """`MongoDBConfig` inválida (host/porta/pool size fora do esperado)."""
+
+    code = "mongodb_invalid_config"

--- a/django/apps/decks/infrastructure/mongodb_config.py
+++ b/django/apps/decks/infrastructure/mongodb_config.py
@@ -11,6 +11,8 @@ import os
 from typing import Optional
 from dataclasses import dataclass
 
+from apps.decks.infrastructure.exceptions import MongoConfigError
+
 
 @dataclass
 class MongoDBConfig:
@@ -96,17 +98,17 @@ class MongoDBConfig:
 
     def validate(self) -> None:
         if not self.host:
-            raise ValueError("MongoDB host cannot be empty")
+            raise MongoConfigError("MongoDB host cannot be empty")
         if not (1 <= self.port <= 65535):
-            raise ValueError("MongoDB port must be between 1 and 65535")
+            raise MongoConfigError("MongoDB port must be between 1 and 65535")
         if not self.database:
-            raise ValueError("MongoDB database name cannot be empty")
+            raise MongoConfigError("MongoDB database name cannot be empty")
         if self.max_pool_size < 1:
-            raise ValueError("Max pool size must be at least 1")
+            raise MongoConfigError("Max pool size must be at least 1")
         if self.min_pool_size < 0:
-            raise ValueError("Min pool size cannot be negative")
+            raise MongoConfigError("Min pool size cannot be negative")
         if self.min_pool_size > self.max_pool_size:
-            raise ValueError("Min pool size cannot be greater than max pool size")
+            raise MongoConfigError("Min pool size cannot be greater than max pool size")
 
     def __str__(self) -> str:
         return f"MongoDBConfig(host={self.host}, port={self.port}, database={self.database}, ssl={self.ssl})"

--- a/django/apps/decks/infrastructure/mongodb_connection.py
+++ b/django/apps/decks/infrastructure/mongodb_connection.py
@@ -18,22 +18,25 @@ from typing import Optional, Dict, Any
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
 from pymongo.errors import ConnectionFailure, ServerSelectionTimeoutError
 
+from apps.decks.infrastructure.exceptions import MongoConfigError, MongoNotConnectedError
 from apps.decks.infrastructure.mongodb_config import get_mongodb_config, MongoDBConfig
+from apps.decks.infrastructure.schemas import IndexDefinitions
 
 
 class MongoDBConnectionManager:
     """
     Gerenciador de conexão MongoDB usando Motor (async).
-    
+
     Implementa o padrão Singleton para garantir uma única instância
     de conexão em toda a aplicação.
     """
-    
+
     _instance: Optional['MongoDBConnectionManager'] = None
     _client: Optional[AsyncIOMotorClient] = None
     _database: Optional[AsyncIOMotorDatabase] = None
     _config: Optional[MongoDBConfig] = None
-    
+    _loop: Optional[asyncio.AbstractEventLoop] = None
+
     def __new__(cls) -> 'MongoDBConnectionManager':
         """
         Implementa o padrão Singleton.
@@ -41,7 +44,7 @@ class MongoDBConnectionManager:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
-    
+
     def __init__(self):
         """
         Inicializa o gerenciador de conexão.
@@ -49,24 +52,24 @@ class MongoDBConnectionManager:
         if not hasattr(self, '_initialized'):
             self._initialized = True
             self._config = get_mongodb_config()
-    
+
     async def connect(self, config: Optional[MongoDBConfig] = None) -> None:
         """
         Estabelece conexão com MongoDB.
-        
+
         Args:
             config: Configuração personalizada (opcional)
-            
+
         Raises:
             ConnectionFailure: Se não conseguir conectar
             ServerSelectionTimeoutError: Se timeout na seleção do servidor
         """
         if config:
             self._config = config
-        
+
         if self._config is None:
-            raise ValueError("MongoDB configuration is required")
-        
+            raise MongoConfigError("MongoDB configuration is required")
+
         try:
             # Cria cliente MongoDB com configurações otimizadas
             connection_params = self._config.get_connection_params()
@@ -75,19 +78,31 @@ class MongoDBConnectionManager:
                 port=connection_params.pop("port"),
                 **connection_params
             )
-            
+
             # Obtém referência do banco
             self._database = self._client[self._config.database]
-            
+
+            # AsyncIOMotorClient fica preso ao event loop ativo no momento em
+            # que é criado. Views Django síncronas chamam o repositório via
+            # `asgiref.sync.async_to_sync`, que — sem um loop "principal" já
+            # rodando na thread — cria um event loop NOVO a cada chamada
+            # (`asyncio.run` por baixo, ver asgiref/sync.py `AsyncToSync.__call__`).
+            # Sem rastrear isso, o client global sobreviveria a um loop já
+            # fechado e toda chamada a partir da segunda quebraria com
+            # `RuntimeError: Event loop is closed` — descoberto rodando a API
+            # de verdade (não só os testes unitários), ver Risks em
+            # openspec/changes/sprint-2-decks-cards/design.md.
+            self._loop = asyncio.get_running_loop()
+
             # Testa a conexão
             await self._test_connection()
-            
+
             print(f"✅ MongoDB conectado: {self._config.host}:{self._config.port}/{self._config.database}")
-            
+
         except (ConnectionFailure, ServerSelectionTimeoutError) as e:
             print(f"❌ Erro ao conectar MongoDB: {e}")
             raise
-    
+
     async def disconnect(self) -> None:
         """
         Fecha a conexão com MongoDB.
@@ -96,12 +111,13 @@ class MongoDBConnectionManager:
             self._client.close()
             self._client = None
             self._database = None
+            self._loop = None
             print("🔌 MongoDB desconectado")
-    
+
     async def _test_connection(self) -> None:
         """
         Testa a conexão com MongoDB.
-        
+
         Raises:
             ConnectionFailure: Se a conexão falhar
         """
@@ -110,11 +126,11 @@ class MongoDBConnectionManager:
             await self._client.admin.command('ping')
         except Exception as e:
             raise ConnectionFailure(f"Failed to ping MongoDB server: {e}")
-    
+
     async def health_check(self) -> Dict[str, Any]:
         """
         Verifica a saúde da conexão MongoDB.
-        
+
         Returns:
             Dicionário com informações de saúde
         """
@@ -123,17 +139,17 @@ class MongoDBConnectionManager:
                 "status": "disconnected",
                 "error": "Not connected to MongoDB"
             }
-        
+
         try:
             # Ping no servidor
             ping_result = await self._client.admin.command('ping')
-            
+
             # Informações do servidor
             server_info = await self._client.server_info()
-            
+
             # Estatísticas do banco
             db_stats = await self._database.command('dbStats')
-            
+
             return {
                 "status": "connected",
                 "ping": ping_result,
@@ -143,131 +159,134 @@ class MongoDBConnectionManager:
                 "data_size": db_stats.get("dataSize", 0),
                 "storage_size": db_stats.get("storageSize", 0)
             }
-            
+
         except Exception as e:
             return {
                 "status": "error",
                 "error": str(e)
             }
-    
+
     def is_connected(self) -> bool:
         """
-        Verifica se está conectado ao MongoDB.
-        
-        Returns:
-            True se conectado, False caso contrário
+        Verifica se está conectado ao MongoDB *no event loop atual*.
+
+        Não basta checar se `_client` existe: um client de uma chamada
+        anterior, criado num event loop já fechado (ver comentário em
+        `connect()`), conta como desconectado — força `ensure_mongodb_connection()`
+        a reconectar (criar um novo `AsyncIOMotorClient`) no loop atual.
         """
-        return self._client is not None and self._database is not None
-    
+        if self._client is None or self._database is None:
+            return False
+
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+
+        return current_loop is self._loop
+
     @property
     def client(self) -> AsyncIOMotorClient:
         """
         Retorna o cliente MongoDB.
-        
+
         Returns:
             Cliente AsyncIOMotorClient
-            
+
         Raises:
-            RuntimeError: Se não estiver conectado
+            MongoNotConnectedError: Se não estiver conectado
         """
         if not self.is_connected():
-            raise RuntimeError("MongoDB not connected. Call connect() first.")
+            raise MongoNotConnectedError("MongoDB not connected. Call connect() first.")
         return self._client
-    
+
     @property
     def database(self) -> AsyncIOMotorDatabase:
         """
         Retorna o banco de dados MongoDB.
-        
+
         Returns:
             Banco AsyncIOMotorDatabase
-            
+
         Raises:
-            RuntimeError: Se não estiver conectado
+            MongoNotConnectedError: Se não estiver conectado
         """
         if not self.is_connected():
-            raise RuntimeError("MongoDB not connected. Call connect() first.")
+            raise MongoNotConnectedError("MongoDB not connected. Call connect() first.")
         return self._database
-    
+
     @property
     def config(self) -> MongoDBConfig:
         """
         Retorna a configuração MongoDB.
-        
+
         Returns:
             Configuração MongoDB
         """
         return self._config
-    
+
     async def get_collection(self, collection_name: str):
         """
         Retorna uma collection do MongoDB.
-        
+
         Args:
             collection_name: Nome da collection
-            
+
         Returns:
             Collection MongoDB
         """
         return self.database[collection_name]
-    
+
     async def create_indexes(self) -> None:
         """
-        Cria índices otimizados para o sistema.
+        Cria índices otimizados para o sistema, a partir da fonte única de
+        verdade em `IndexDefinitions` (schemas.py) — evita duas listas de
+        índices divergentes (ver `<regra_obrigatoria>` sobre índices em
+        PROMPT_REFINADO.md).
         """
         if not self.is_connected():
-            raise RuntimeError("MongoDB not connected. Call connect() first.")
-        
-        # Índices para collection cards
-        cards_collection = await self.get_collection("cards")
-        await cards_collection.create_index("deck_id")
-        await cards_collection.create_index("word.normalized")
-        await cards_collection.create_index("created_at")
-        await cards_collection.create_index([("deck_id", 1), ("word.normalized", 1)], unique=True)
-        
-        # Índices para collection decks
-        decks_collection = await self.get_collection("decks")
-        await decks_collection.create_index("title")
-        await decks_collection.create_index("created_at")
-        await decks_collection.create_index("updated_at")
-        
-        # Índices para collection generation_sessions
-        sessions_collection = await self.get_collection("generation_sessions")
-        await sessions_collection.create_index("deck_id")
-        await sessions_collection.create_index("status")
-        await sessions_collection.create_index("created_at")
-        await sessions_collection.create_index("completed_at")
-        
+            raise MongoNotConnectedError("MongoDB not connected. Call connect() first.")
+
+        for collection_name, index_defs in IndexDefinitions.get_all_indexes().items():
+            collection = await self.get_collection(collection_name)
+            for index_def in index_defs:
+                if isinstance(index_def, tuple) and isinstance(index_def[0], str):
+                    field_name, direction = index_def
+                    await collection.create_index([(field_name, direction)])
+                else:
+                    keys, options = index_def
+                    await collection.create_index(keys, **options)
+
         print("✅ Índices MongoDB criados com sucesso")
-    
+
     async def drop_collection(self, collection_name: str) -> None:
         """
         Remove uma collection (apenas para desenvolvimento/testes).
-        
+
         Args:
             collection_name: Nome da collection
         """
         if not self.is_connected():
-            raise RuntimeError("MongoDB not connected. Call connect() first.")
-        
+            raise MongoNotConnectedError("MongoDB not connected. Call connect() first.")
+
         await self.database.drop_collection(collection_name)
         print(f"🗑️ Collection '{collection_name}' removida")
-    
+
     async def get_database_info(self) -> Dict[str, Any]:
         """
         Retorna informações sobre o banco de dados.
-        
+
         Returns:
             Dicionário com informações do banco
         """
         if not self.is_connected():
-            raise RuntimeError("MongoDB not connected. Call connect() first.")
-        
+            raise MongoNotConnectedError("MongoDB not connected. Call connect() first.")
+
         db_stats = await self._database.command('dbStats')
-        
+
         # Lista collections
         collections = await self._database.list_collection_names()
-        
+
         return {
             "database_name": self._config.database,
             "collections": collections,
@@ -286,7 +305,7 @@ mongodb_manager = MongoDBConnectionManager()
 async def get_mongodb_manager() -> MongoDBConnectionManager:
     """
     Retorna a instância global do gerenciador MongoDB.
-    
+
     Returns:
         Gerenciador MongoDB
     """
@@ -296,16 +315,16 @@ async def get_mongodb_manager() -> MongoDBConnectionManager:
 async def ensure_mongodb_connection() -> MongoDBConnectionManager:
     """
     Garante que a conexão MongoDB está estabelecida.
-    
+
     Returns:
         Gerenciador MongoDB conectado
-        
+
     Raises:
         ConnectionFailure: Se não conseguir conectar
     """
     manager = await get_mongodb_manager()
-    
+
     if not manager.is_connected():
         await manager.connect()
-    
+
     return manager

--- a/django/apps/decks/infrastructure/repositories/__init__.py
+++ b/django/apps/decks/infrastructure/repositories/__init__.py
@@ -6,20 +6,32 @@ Cada repositório implementa sua respectiva interface do domínio.
 
 Implementações disponíveis:
 - CardRepository: Implementação MongoDB do ICardRepository
-- DeckRepository: Implementação MongoDB do IDeckRepository  
+- DeckRepository: Implementação MongoDB do IDeckRepository
 - GenerationSessionRepository: Implementação MongoDB do IGenerationSessionRepository
 """
 
-from .card_repository import CardRepository, RepositoryError, CardNotFoundError
-from .deck_repository import DeckRepository, DeckNotFoundError
-from .generation_session_repository import GenerationSessionRepository, SessionNotFoundError
+from .card_repository import CardRepository
+from .deck_repository import DeckRepository
+from .category_repository import CategoryRepository
+from .card_review_repository import CardReviewRepository
+from .generation_session_repository import GenerationSessionRepository
+from ..exceptions import (
+    CardNotFoundError,
+    CategoryNotFoundError,
+    DeckNotFoundError,
+    RepositoryError,
+    SessionNotFoundError,
+)
 
 __all__ = [
     'CardRepository',
-    'DeckRepository', 
+    'DeckRepository',
+    'CategoryRepository',
+    'CardReviewRepository',
     'GenerationSessionRepository',
     'RepositoryError',
     'CardNotFoundError',
     'DeckNotFoundError',
+    'CategoryNotFoundError',
     'SessionNotFoundError'
 ]

--- a/django/apps/decks/infrastructure/repositories/card_repository.py
+++ b/django/apps/decks/infrastructure/repositories/card_repository.py
@@ -2,17 +2,14 @@
 Implementação MongoDB do CardRepository
 
 Este módulo implementa a interface ICardRepository usando MongoDB como
-banco de dados. Utiliza Motor para operações assíncronas e implementa
-todas as operações definidas na interface.
-
-Características:
-- Operações assíncronas com Motor
-- Validação de dados com schemas
-- Tratamento de erros específicos
-- Otimizações de performance
+banco de dados, via Motor (async). Toda operação de leitura/escrita exige
+`owner_id` e embute esse filtro diretamente na query — nunca busca por ID e
+confere o dono depois em Python (ver D1 em
+openspec/changes/sprint-2-decks-cards/design.md).
 """
 
 import uuid
+from datetime import datetime, timezone
 from typing import List, Optional
 from motor.motor_asyncio import AsyncIOMotorCollection
 from pymongo.errors import DuplicateKeyError, OperationFailure
@@ -20,482 +17,268 @@ from bson import ObjectId
 
 from apps.decks.domain.entities.card import Card
 from apps.decks.domain.repositories.icard_repository import ICardRepository
+from apps.decks.infrastructure.exceptions import CardNotFoundError, RepositoryError
 from apps.decks.infrastructure.mongodb_connection import ensure_mongodb_connection
 from apps.decks.infrastructure.schemas import CardSchema, uuid_to_object_id
 
 
-class RepositoryError(Exception):
-    """
-    Exceção base para erros de repositório.
-    """
-    pass
-
-
-class CardNotFoundError(RepositoryError):
-    """
-    Exceção para quando um card não é encontrado.
-    """
-    pass
-
-
 class CardRepository(ICardRepository):
-    """
-    Implementação MongoDB do CardRepository.
-    
-    Implementa todas as operações definidas na interface ICardRepository
-    usando MongoDB como banco de dados.
-    """
-    
+    """Implementação MongoDB do CardRepository."""
+
     def __init__(self):
-        """
-        Inicializa o repositório.
-        """
         self._collection_name = "cards"
-        self._collection: Optional[AsyncIOMotorCollection] = None
-    
+
     async def _get_collection(self) -> AsyncIOMotorCollection:
-        """
-        Retorna a collection MongoDB.
-        
-        Returns:
-            Collection MongoDB
-            
-        Raises:
-            RepositoryError: Se não conseguir conectar
-        """
-        if self._collection is None:
-            try:
-                mongodb_manager = await ensure_mongodb_connection()
-                self._collection = await mongodb_manager.get_collection(self._collection_name)
-            except Exception as e:
-                raise RepositoryError(f"Failed to get MongoDB collection: {e}")
-        
-        return self._collection
-    
+        # Nunca cacheia a collection na instância: `AsyncIOMotorClient` fica
+        # preso ao event loop em que foi criado, e uma mesma instância de
+        # repositório pode ser reusada em chamadas separadas via
+        # `async_to_sync` — cada uma com o seu próprio event loop novo (ver
+        # comentário em mongodb_connection.py `connect()`/`is_connected()`).
+        # `ensure_mongodb_connection()` já é barato quando o loop não mudou.
+        try:
+            mongodb_manager = await ensure_mongodb_connection()
+            return await mongodb_manager.get_collection(self._collection_name)
+        except Exception as e:
+            raise RepositoryError(f"Failed to get MongoDB collection: {e}")
+
     async def save(self, card: Card) -> Card:
-        """
-        Salva um card no banco de dados.
-        
-        Args:
-            card: Card a ser salvo
-            
-        Returns:
-            Card salvo
-            
-        Raises:
-            RepositoryError: Se houver erro na persistência
-        """
         try:
             collection = await self._get_collection()
             card_data = card.to_dict()
             document = CardSchema.to_document(card_data)
-            
-            # Insere o documento
+
             result = await collection.insert_one(document)
-            
-            # Atualiza o ID do card com o ObjectId gerado
             card.id = uuid.UUID(int=int(str(result.inserted_id), 16))
-            
+
             return card
-            
+
         except DuplicateKeyError as e:
             raise RepositoryError(f"Card with duplicate key: {e}")
         except Exception as e:
             raise RepositoryError(f"Failed to save card: {e}")
-    
+
     async def save_many(self, cards: List[Card]) -> List[Card]:
-        """
-        Salva múltiplos cards no banco de dados.
-        
-        Args:
-            cards: Lista de cards a serem salvos
-            
-        Returns:
-            Lista de cards salvos
-            
-        Raises:
-            RepositoryError: Se houver erro na persistência
-        """
         if not cards:
             return []
-        
+
         try:
             collection = await self._get_collection()
-            documents = []
-            
-            # Converte todos os cards para documentos
-            for card in cards:
-                card_data = card.to_dict()
-                document = CardSchema.to_document(card_data)
-                documents.append(document)
-            
-            # Insere todos os documentos
+            documents = [CardSchema.to_document(card.to_dict()) for card in cards]
+
             result = await collection.insert_many(documents)
-            
-            # Atualiza os IDs dos cards
+
             for i, card in enumerate(cards):
                 card.id = uuid.UUID(int=int(str(result.inserted_ids[i]), 16))
-            
+
             return cards
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to save cards: {e}")
-    
-    async def find_by_id(self, card_id: uuid.UUID) -> Optional[Card]:
-        """
-        Busca um card pelo ID.
-        
-        Args:
-            card_id: ID do card
-            
-        Returns:
-            Card se encontrado, None caso contrário
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+
+    async def find_by_id(self, card_id: uuid.UUID, owner_id: str) -> Optional[Card]:
         try:
             collection = await self._get_collection()
-            document = await collection.find_one({"_id": uuid_to_object_id(card_id)})
-            
+            document = await collection.find_one({
+                "_id": uuid_to_object_id(card_id),
+                "owner_id": owner_id,
+            })
+
             if document is None:
                 return None
-            
+
             card_data = CardSchema.from_document(document)
             return Card.from_dict(card_data)
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to find card by ID: {e}")
-    
-    async def find_by_word(self, word: str) -> List[Card]:
-        """
-        Busca cards por palavra.
-        
-        Args:
-            word: Palavra para buscar (case insensitive)
-            
-        Returns:
-            Lista de cards que contêm a palavra
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+
+    async def find_by_word(self, word: str, owner_id: str) -> List[Card]:
         try:
             collection = await self._get_collection()
             word_normalized = word.lower().strip()
-            
-            # Busca por palavra normalizada
-            cursor = collection.find({"word.normalized": word_normalized})
+
+            cursor = collection.find({
+                "word.normalized": word_normalized,
+                "owner_id": owner_id,
+            })
             documents = await cursor.to_list(length=None)
-            
-            cards = []
-            for document in documents:
-                card_data = CardSchema.from_document(document)
-                card = Card.from_dict(card_data)
-                cards.append(card)
-            
-            return cards
-            
+
+            return [Card.from_dict(CardSchema.from_document(doc)) for doc in documents]
+
         except Exception as e:
             raise RepositoryError(f"Failed to find cards by word: {e}")
-    
-    async def find_by_deck_id(self, deck_id: uuid.UUID) -> List[Card]:
-        """
-        Busca todos os cards de um deck.
-        
-        Args:
-            deck_id: ID do deck
-            
-        Returns:
-            Lista de cards do deck
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+
+    async def find_by_deck_id(self, deck_id: uuid.UUID, owner_id: str) -> List[Card]:
         try:
             collection = await self._get_collection()
-            cursor = collection.find({"deck_id": uuid_to_object_id(deck_id)})
+            cursor = collection.find({
+                "deck_id": uuid_to_object_id(deck_id),
+                "owner_id": owner_id,
+            })
             documents = await cursor.to_list(length=None)
-            
-            cards = []
-            for document in documents:
-                card_data = CardSchema.from_document(document)
-                card = Card.from_dict(card_data)
-                cards.append(card)
-            
-            return cards
-            
+
+            return [Card.from_dict(CardSchema.from_document(doc)) for doc in documents]
+
         except Exception as e:
             raise RepositoryError(f"Failed to find cards by deck ID: {e}")
-    
-    async def find_by_context(self, context: str) -> List[Card]:
-        """
-        Busca cards por contexto.
-        
-        Args:
-            context: Contexto para buscar
-            
-        Returns:
-            Lista de cards que usam o contexto
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+
+    async def find_by_context(self, context: str, owner_id: str) -> List[Card]:
         try:
             collection = await self._get_collection()
-            cursor = collection.find({"context": context})
+            cursor = collection.find({"context": context, "owner_id": owner_id})
             documents = await cursor.to_list(length=None)
-            
-            cards = []
-            for document in documents:
-                card_data = CardSchema.from_document(document)
-                card = Card.from_dict(card_data)
-                cards.append(card)
-            
-            return cards
-            
+
+            return [Card.from_dict(CardSchema.from_document(doc)) for doc in documents]
+
         except Exception as e:
             raise RepositoryError(f"Failed to find cards by context: {e}")
-    
-    async def find_similar_cards(self, word: str, similarity_threshold: float = 0.8) -> List[Card]:
-        """
-        Busca cards similares à palavra especificada.
-        
-        Args:
-            word: Palavra para comparar
-            similarity_threshold: Limiar de similaridade (0.0 a 1.0)
-            
-        Returns:
-            Lista de cards similares
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+
+    async def find_similar_cards(self, word: str, owner_id: str, similarity_threshold: float = 0.8) -> List[Card]:
         try:
             collection = await self._get_collection()
             word_normalized = word.lower().strip()
-            
-            # Usa regex para busca parcial (implementação simples)
-            # Em uma implementação mais sofisticada, usaria text search ou aggregation
             regex_pattern = f".*{word_normalized}.*"
-            
+
             cursor = collection.find({
+                "owner_id": owner_id,
                 "$or": [
                     {"word.normalized": {"$regex": regex_pattern, "$options": "i"}},
                     {"translation.normalized": {"$regex": regex_pattern, "$options": "i"}}
                 ]
             })
-            
+
             documents = await cursor.to_list(length=None)
-            
-            cards = []
-            for document in documents:
-                card_data = CardSchema.from_document(document)
-                card = Card.from_dict(card_data)
-                cards.append(card)
-            
-            return cards
-            
+
+            return [Card.from_dict(CardSchema.from_document(doc)) for doc in documents]
+
         except Exception as e:
             raise RepositoryError(f"Failed to find similar cards: {e}")
-    
-    async def find_duplicates(self, card: Card) -> List[Card]:
-        """
-        Busca cards duplicados ou muito similares.
-        
-        Args:
-            card: Card para verificar duplicatas
-            
-        Returns:
-            Lista de cards duplicados/similares
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+
+    async def find_duplicates(self, card: Card, owner_id: str) -> List[Card]:
         try:
             collection = await self._get_collection()
-            
-            # Busca por palavra exata
+
             exact_matches = await collection.find({
-                "word.normalized": card.word.normalized
+                "word.normalized": card.word.normalized,
+                "owner_id": owner_id,
             }).to_list(length=None)
-            
+
             cards = []
             for document in exact_matches:
-                # Não inclui o próprio card
                 if str(document["_id"]) != str(card.id):
-                    card_data = CardSchema.from_document(document)
-                    duplicate_card = Card.from_dict(card_data)
-                    cards.append(duplicate_card)
-            
+                    cards.append(Card.from_dict(CardSchema.from_document(document)))
+
             return cards
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to find duplicates: {e}")
-    
+
+    async def find_due(self, owner_id: str, due_before: Optional[datetime] = None) -> List[Card]:
+        try:
+            collection = await self._get_collection()
+            due_before = due_before or datetime.now(timezone.utc)
+
+            cursor = collection.find({
+                "owner_id": owner_id,
+                "due_at": {"$lte": due_before},
+            }).sort("due_at", 1)
+            documents = await cursor.to_list(length=None)
+
+            return [Card.from_dict(CardSchema.from_document(doc)) for doc in documents]
+
+        except Exception as e:
+            raise RepositoryError(f"Failed to find due cards: {e}")
+
     async def update(self, card: Card) -> Card:
-        """
-        Atualiza um card existente.
-        
-        Args:
-            card: Card com dados atualizados
-            
-        Returns:
-            Card atualizado
-            
-        Raises:
-            RepositoryError: Se houver erro na atualização
-            CardNotFoundError: Se o card não existir
-        """
         try:
             collection = await self._get_collection()
             card_data = card.to_dict()
             document = CardSchema.to_document(card_data)
-            
-            # Remove o _id do documento para atualização
             document.pop("_id", None)
-            
+
             result = await collection.replace_one(
-                {"_id": uuid_to_object_id(card.id)},
+                {"_id": uuid_to_object_id(card.id), "owner_id": card.owner_id},
                 document
             )
-            
+
             if result.matched_count == 0:
                 raise CardNotFoundError(f"Card with ID {card.id} not found")
-            
+
             return card
-            
+
         except CardNotFoundError:
             raise
         except Exception as e:
             raise RepositoryError(f"Failed to update card: {e}")
-    
-    async def delete(self, card_id: uuid.UUID) -> bool:
-        """
-        Remove um card do banco de dados.
-        
-        Args:
-            card_id: ID do card a ser removido
-            
-        Returns:
-            True se o card foi removido, False se não foi encontrado
-            
-        Raises:
-            RepositoryError: Se houver erro na remoção
-        """
+
+    async def delete(self, card_id: uuid.UUID, owner_id: str) -> bool:
         try:
             collection = await self._get_collection()
-            result = await collection.delete_one({"_id": uuid_to_object_id(card_id)})
-            
+            result = await collection.delete_one({
+                "_id": uuid_to_object_id(card_id),
+                "owner_id": owner_id,
+            })
+
             return result.deleted_count > 0
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to delete card: {e}")
-    
-    async def delete_by_deck_id(self, deck_id: uuid.UUID) -> int:
-        """
-        Remove todos os cards de um deck.
-        
-        Args:
-            deck_id: ID do deck
-            
-        Returns:
-            Número de cards removidos
-            
-        Raises:
-            RepositoryError: Se houver erro na remoção
-        """
+
+    async def delete_by_deck_id(self, deck_id: uuid.UUID, owner_id: str) -> int:
         try:
             collection = await self._get_collection()
-            result = await collection.delete_many({"deck_id": uuid_to_object_id(deck_id)})
-            
+            result = await collection.delete_many({
+                "deck_id": uuid_to_object_id(deck_id),
+                "owner_id": owner_id,
+            })
+
             return result.deleted_count
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to delete cards by deck ID: {e}")
-    
-    async def count(self) -> int:
-        """
-        Conta o total de cards no banco.
-        
-        Returns:
-            Número total de cards
-            
-        Raises:
-            RepositoryError: Se houver erro na contagem
-        """
+
+    async def count(self, owner_id: str) -> int:
         try:
             collection = await self._get_collection()
-            return await collection.count_documents({})
-            
+            return await collection.count_documents({"owner_id": owner_id})
+
         except Exception as e:
             raise RepositoryError(f"Failed to count cards: {e}")
-    
-    async def count_by_deck_id(self, deck_id: uuid.UUID) -> int:
-        """
-        Conta o número de cards de um deck.
-        
-        Args:
-            deck_id: ID do deck
-            
-        Returns:
-            Número de cards do deck
-            
-        Raises:
-            RepositoryError: Se houver erro na contagem
-        """
+
+    async def count_by_deck_id(self, deck_id: uuid.UUID, owner_id: str) -> int:
         try:
             collection = await self._get_collection()
-            return await collection.count_documents({"deck_id": uuid_to_object_id(deck_id)})
-            
+            return await collection.count_documents({
+                "deck_id": uuid_to_object_id(deck_id),
+                "owner_id": owner_id,
+            })
+
         except Exception as e:
             raise RepositoryError(f"Failed to count cards by deck ID: {e}")
-    
-    async def exists(self, card_id: uuid.UUID) -> bool:
-        """
-        Verifica se um card existe.
-        
-        Args:
-            card_id: ID do card
-            
-        Returns:
-            True se o card existe, False caso contrário
-            
-        Raises:
-            RepositoryError: Se houver erro na verificação
-        """
+
+    async def exists(self, card_id: uuid.UUID, owner_id: str) -> bool:
         try:
             collection = await self._get_collection()
-            count = await collection.count_documents({"_id": uuid_to_object_id(card_id)})
+            count = await collection.count_documents({
+                "_id": uuid_to_object_id(card_id),
+                "owner_id": owner_id,
+            })
             return count > 0
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to check if card exists: {e}")
-    
-    async def exists_by_word(self, word: str, deck_id: Optional[uuid.UUID] = None) -> bool:
-        """
-        Verifica se já existe um card com a palavra especificada.
-        
-        Args:
-            word: Palavra para verificar
-            deck_id: ID do deck (opcional, para verificar apenas em um deck)
-            
-        Returns:
-            True se já existe um card com essa palavra
-            
-        Raises:
-            RepositoryError: Se houver erro na verificação
-        """
+
+    async def exists_by_word(self, word: str, owner_id: str, deck_id: Optional[uuid.UUID] = None) -> bool:
         try:
             collection = await self._get_collection()
             word_normalized = word.lower().strip()
-            
-            query = {"word.normalized": word_normalized}
+
+            query = {"word.normalized": word_normalized, "owner_id": owner_id}
             if deck_id:
                 query["deck_id"] = uuid_to_object_id(deck_id)
-            
+
             count = await collection.count_documents(query)
             return count > 0
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to check if word exists: {e}")

--- a/django/apps/decks/infrastructure/repositories/card_review_repository.py
+++ b/django/apps/decks/infrastructure/repositories/card_review_repository.py
@@ -1,0 +1,58 @@
+"""
+Implementação MongoDB do CardReviewRepository — um documento por evento de
+revisão, owner_id obrigatório (ver D1/D5 em
+openspec/changes/sprint-2-decks-cards/design.md).
+"""
+
+import uuid
+from typing import List, Optional
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from apps.decks.domain.entities.card_review import CardReview
+from apps.decks.domain.repositories.icard_review_repository import ICardReviewRepository
+from apps.decks.infrastructure.exceptions import RepositoryError
+from apps.decks.infrastructure.mongodb_connection import ensure_mongodb_connection
+from apps.decks.infrastructure.schemas import CardReviewSchema, uuid_to_object_id
+
+
+class CardReviewRepository(ICardReviewRepository):
+    """Implementação MongoDB do CardReviewRepository."""
+
+    def __init__(self):
+        self._collection_name = "card_reviews"
+
+    async def _get_collection(self) -> AsyncIOMotorCollection:
+        # Nunca cacheia a collection na instância — ver comentário
+        # equivalente em CardRepository._get_collection().
+        try:
+            mongodb_manager = await ensure_mongodb_connection()
+            return await mongodb_manager.get_collection(self._collection_name)
+        except Exception as e:
+            raise RepositoryError(f"Failed to get MongoDB collection: {e}")
+
+    async def save(self, review: CardReview) -> CardReview:
+        try:
+            collection = await self._get_collection()
+            document = CardReviewSchema.to_document(review.to_dict())
+
+            result = await collection.insert_one(document)
+            review.id = uuid.UUID(int=int(str(result.inserted_id), 16))
+
+            return review
+
+        except Exception as e:
+            raise RepositoryError(f"Failed to save card review: {e}")
+
+    async def find_by_card_id(self, card_id: uuid.UUID, owner_id: str) -> List[CardReview]:
+        try:
+            collection = await self._get_collection()
+            cursor = collection.find({
+                "card_id": uuid_to_object_id(card_id),
+                "owner_id": owner_id,
+            }).sort("reviewed_at", -1)
+            documents = await cursor.to_list(length=None)
+
+            return [CardReview.from_dict(CardReviewSchema.from_document(doc)) for doc in documents]
+
+        except Exception as e:
+            raise RepositoryError(f"Failed to find reviews by card ID: {e}")

--- a/django/apps/decks/infrastructure/repositories/category_repository.py
+++ b/django/apps/decks/infrastructure/repositories/category_repository.py
@@ -1,0 +1,117 @@
+"""
+Implementação MongoDB do CategoryRepository — mesmo padrão de owner_id
+obrigatório dos demais repositórios (ver D1/D6 em
+openspec/changes/sprint-2-decks-cards/design.md).
+"""
+
+import uuid
+from typing import List, Optional
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from apps.decks.domain.entities.category import Category
+from apps.decks.domain.repositories.icategory_repository import ICategoryRepository
+from apps.decks.infrastructure.exceptions import CategoryNotFoundError, RepositoryError
+from apps.decks.infrastructure.mongodb_connection import ensure_mongodb_connection
+from apps.decks.infrastructure.schemas import CategorySchema, uuid_to_object_id
+
+
+class CategoryRepository(ICategoryRepository):
+    """Implementação MongoDB do CategoryRepository."""
+
+    def __init__(self):
+        self._collection_name = "categories"
+
+    async def _get_collection(self) -> AsyncIOMotorCollection:
+        # Nunca cacheia a collection na instância — ver comentário
+        # equivalente em CardRepository._get_collection().
+        try:
+            mongodb_manager = await ensure_mongodb_connection()
+            return await mongodb_manager.get_collection(self._collection_name)
+        except Exception as e:
+            raise RepositoryError(f"Failed to get MongoDB collection: {e}")
+
+    async def save(self, category: Category) -> Category:
+        try:
+            collection = await self._get_collection()
+            document = CategorySchema.to_document(category.to_dict())
+
+            result = await collection.insert_one(document)
+            category.id = uuid.UUID(int=int(str(result.inserted_id), 16))
+
+            return category
+
+        except Exception as e:
+            raise RepositoryError(f"Failed to save category: {e}")
+
+    async def find_by_id(self, category_id: uuid.UUID, owner_id: str) -> Optional[Category]:
+        try:
+            collection = await self._get_collection()
+            document = await collection.find_one({
+                "_id": uuid_to_object_id(category_id),
+                "owner_id": owner_id,
+            })
+
+            if document is None:
+                return None
+
+            return Category.from_dict(CategorySchema.from_document(document))
+
+        except Exception as e:
+            raise RepositoryError(f"Failed to find category by ID: {e}")
+
+    async def find_all(self, owner_id: str) -> List[Category]:
+        try:
+            collection = await self._get_collection()
+            cursor = collection.find({"owner_id": owner_id}).sort("name", 1)
+            documents = await cursor.to_list(length=None)
+
+            return [Category.from_dict(CategorySchema.from_document(doc)) for doc in documents]
+
+        except Exception as e:
+            raise RepositoryError(f"Failed to find categories: {e}")
+
+    async def update(self, category: Category) -> Category:
+        try:
+            collection = await self._get_collection()
+            document = CategorySchema.to_document(category.to_dict())
+            document.pop("_id", None)
+
+            result = await collection.replace_one(
+                {"_id": uuid_to_object_id(category.id), "owner_id": category.owner_id},
+                document
+            )
+
+            if result.matched_count == 0:
+                raise CategoryNotFoundError(f"Category with ID {category.id} not found")
+
+            return category
+
+        except CategoryNotFoundError:
+            raise
+        except Exception as e:
+            raise RepositoryError(f"Failed to update category: {e}")
+
+    async def delete(self, category_id: uuid.UUID, owner_id: str) -> bool:
+        try:
+            collection = await self._get_collection()
+            result = await collection.delete_one({
+                "_id": uuid_to_object_id(category_id),
+                "owner_id": owner_id,
+            })
+
+            return result.deleted_count > 0
+
+        except Exception as e:
+            raise RepositoryError(f"Failed to delete category: {e}")
+
+    async def exists(self, category_id: uuid.UUID, owner_id: str) -> bool:
+        try:
+            collection = await self._get_collection()
+            count = await collection.count_documents({
+                "_id": uuid_to_object_id(category_id),
+                "owner_id": owner_id,
+            })
+            return count > 0
+
+        except Exception as e:
+            raise RepositoryError(f"Failed to check if category exists: {e}")

--- a/django/apps/decks/infrastructure/repositories/deck_repository.py
+++ b/django/apps/decks/infrastructure/repositories/deck_repository.py
@@ -2,8 +2,9 @@
 Implementação MongoDB do DeckRepository
 
 Este módulo implementa a interface IDeckRepository usando MongoDB como
-banco de dados. Utiliza Motor para operações assíncronas e implementa
-todas as operações definidas na interface.
+banco de dados, via Motor (async). Toda operação de leitura/escrita exige
+`owner_id` e embute esse filtro diretamente na query (ver D1 em
+openspec/changes/sprint-2-decks-cards/design.md).
 """
 
 import uuid
@@ -14,371 +15,195 @@ from bson import ObjectId
 
 from apps.decks.domain.entities.deck import Deck
 from apps.decks.domain.repositories.ideck_repository import IDeckRepository
+from apps.decks.infrastructure.exceptions import DeckNotFoundError, RepositoryError
 from apps.decks.infrastructure.mongodb_connection import ensure_mongodb_connection
 from apps.decks.infrastructure.schemas import DeckSchema, uuid_to_object_id
-from apps.decks.infrastructure.repositories.card_repository import RepositoryError
-
-
-class DeckNotFoundError(RepositoryError):
-    """
-    Exceção para quando um deck não é encontrado.
-    """
-    pass
 
 
 class DeckRepository(IDeckRepository):
-    """
-    Implementação MongoDB do DeckRepository.
-    
-    Implementa todas as operações definidas na interface IDeckRepository
-    usando MongoDB como banco de dados.
-    """
-    
+    """Implementação MongoDB do DeckRepository."""
+
     def __init__(self):
-        """
-        Inicializa o repositório.
-        """
         self._collection_name = "decks"
-        self._collection: Optional[AsyncIOMotorCollection] = None
-    
+
     async def _get_collection(self) -> AsyncIOMotorCollection:
-        """
-        Retorna a collection MongoDB.
-        
-        Returns:
-            Collection MongoDB
-            
-        Raises:
-            RepositoryError: Se não conseguir conectar
-        """
-        if self._collection is None:
-            try:
-                mongodb_manager = await ensure_mongodb_connection()
-                self._collection = await mongodb_manager.get_collection(self._collection_name)
-            except Exception as e:
-                raise RepositoryError(f"Failed to get MongoDB collection: {e}")
-        
-        return self._collection
-    
+        # Nunca cacheia a collection na instância — ver comentário
+        # equivalente em CardRepository._get_collection().
+        try:
+            mongodb_manager = await ensure_mongodb_connection()
+            return await mongodb_manager.get_collection(self._collection_name)
+        except Exception as e:
+            raise RepositoryError(f"Failed to get MongoDB collection: {e}")
+
     async def save(self, deck: Deck) -> Deck:
-        """
-        Salva um deck no banco de dados.
-        
-        Args:
-            deck: Deck a ser salvo
-            
-        Returns:
-            Deck salvo
-            
-        Raises:
-            RepositoryError: Se houver erro na persistência
-        """
         try:
             collection = await self._get_collection()
             deck_data = deck.to_dict()
             document = DeckSchema.to_document(deck_data)
-            
-            # Insere o documento
+
             result = await collection.insert_one(document)
-            
-            # Atualiza o ID do deck com o ObjectId gerado (converte para UUID)
             deck.id = uuid.UUID(int=int(str(result.inserted_id), 16))
-            
+
             return deck
-            
+
         except DuplicateKeyError as e:
             raise RepositoryError(f"Deck with duplicate key: {e}")
         except Exception as e:
             raise RepositoryError(f"Failed to save deck: {e}")
-    
-    async def find_by_id(self, deck_id: uuid.UUID) -> Optional[Deck]:
-        """
-        Busca um deck pelo ID.
-        
-        Args:
-            deck_id: ID do deck
-            
-        Returns:
-            Deck se encontrado, None caso contrário
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+
+    async def find_by_id(self, deck_id: uuid.UUID, owner_id: str) -> Optional[Deck]:
         try:
             collection = await self._get_collection()
-            document = await collection.find_one({"_id": uuid_to_object_id(deck_id)})
-            
+            document = await collection.find_one({
+                "_id": uuid_to_object_id(deck_id),
+                "owner_id": owner_id,
+            })
+
             if document is None:
                 return None
-            
+
             deck_data = DeckSchema.from_document(document)
             deck = Deck.from_dict(deck_data)
-            
-            # Carrega os cards do deck
+
             from apps.decks.infrastructure.repositories.card_repository import CardRepository
             card_repository = CardRepository()
-            cards = await card_repository.find_by_deck_id(deck_id)
-            deck.cards = cards
-            
+            deck.cards = await card_repository.find_by_deck_id(deck_id, owner_id)
+
             return deck
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to find deck by ID: {e}")
-    
-    async def find_by_title(self, title: str) -> List[Deck]:
-        """
-        Busca decks por título.
-        
-        Args:
-            title: Título para buscar (case insensitive)
-            
-        Returns:
-            Lista de decks com títulos similares
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+
+    async def find_by_title(self, title: str, owner_id: str) -> List[Deck]:
         try:
             collection = await self._get_collection()
-            
-            # Busca case insensitive
+
             cursor = collection.find({
-                "title": {"$regex": title, "$options": "i"}
+                "title": {"$regex": title, "$options": "i"},
+                "owner_id": owner_id,
             })
             documents = await cursor.to_list(length=None)
-            
-            decks = []
-            for document in documents:
-                deck_data = DeckSchema.from_document(document)
-                deck = Deck.from_dict(deck_data)
-                decks.append(deck)
-            
-            return decks
-            
+
+            return [Deck.from_dict(DeckSchema.from_document(doc)) for doc in documents]
+
         except Exception as e:
             raise RepositoryError(f"Failed to find decks by title: {e}")
-    
-    async def find_all(self, skip: int = 0, limit: int = 100) -> List[Deck]:
-        """
-        Busca todos os decks com paginação.
-        
-        Args:
-            skip: Número de registros para pular
-            limit: Número máximo de registros a retornar
-            
-        Returns:
-            Lista de decks
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
+
+    async def find_all(self, owner_id: str, skip: int = 0, limit: int = 100) -> List[Deck]:
         try:
             collection = await self._get_collection()
-            cursor = collection.find().skip(skip).limit(limit).sort("created_at", -1)
+            cursor = (
+                collection.find({"owner_id": owner_id})
+                .skip(skip)
+                .limit(limit)
+                .sort("created_at", -1)
+            )
             documents = await cursor.to_list(length=None)
-            
-            decks = []
-            for document in documents:
-                deck_data = DeckSchema.from_document(document)
-                deck = Deck.from_dict(deck_data)
-                decks.append(deck)
-            
-            return decks
-            
+
+            return [Deck.from_dict(DeckSchema.from_document(doc)) for doc in documents]
+
         except Exception as e:
             raise RepositoryError(f"Failed to find all decks: {e}")
-    
+
     async def find_by_user_id(self, user_id: str, skip: int = 0, limit: int = 100) -> List[Deck]:
-        """
-        Busca decks de um usuário específico.
-        
-        Args:
-            user_id: ID do usuário
-            skip: Número de registros para pular
-            limit: Número máximo de registros a retornar
-            
-        Returns:
-            Lista de decks do usuário
-            
-        Raises:
-            RepositoryError: Se houver erro na consulta
-        """
         try:
             collection = await self._get_collection()
-            
-            # Por enquanto, retorna todos os decks
-            # Em uma implementação futura, adicionaríamos campo user_id
-            cursor = collection.find().skip(skip).limit(limit).sort("created_at", -1)
+            cursor = (
+                collection.find({"owner_id": user_id})
+                .skip(skip)
+                .limit(limit)
+                .sort("created_at", -1)
+            )
             documents = await cursor.to_list(length=None)
-            
-            decks = []
-            for document in documents:
-                deck_data = DeckSchema.from_document(document)
-                deck = Deck.from_dict(deck_data)
-                decks.append(deck)
-            
-            return decks
-            
+
+            return [Deck.from_dict(DeckSchema.from_document(doc)) for doc in documents]
+
         except Exception as e:
             raise RepositoryError(f"Failed to find decks by user ID: {e}")
-    
+
     async def update(self, deck: Deck) -> Deck:
-        """
-        Atualiza um deck existente.
-        
-        Args:
-            deck: Deck com dados atualizados
-            
-        Returns:
-            Deck atualizado
-            
-        Raises:
-            RepositoryError: Se houver erro na atualização
-            DeckNotFoundError: Se o deck não existir
-        """
         try:
             collection = await self._get_collection()
             deck_data = deck.to_dict()
             document = DeckSchema.to_document(deck_data)
-            
-            # Remove o _id do documento para atualização
             document.pop("_id", None)
-            
+
             result = await collection.replace_one(
-                {"_id": uuid_to_object_id(deck.id)},
+                {"_id": uuid_to_object_id(deck.id), "owner_id": deck.owner_id},
                 document
             )
-            
+
             if result.matched_count == 0:
                 raise DeckNotFoundError(f"Deck with ID {deck.id} not found")
-            
+
             return deck
-            
+
         except DeckNotFoundError:
             raise
         except Exception as e:
             raise RepositoryError(f"Failed to update deck: {e}")
-    
-    async def delete(self, deck_id: uuid.UUID) -> bool:
-        """
-        Remove um deck do banco de dados.
-        
-        Args:
-            deck_id: ID do deck a ser removido
-            
-        Returns:
-            True se o deck foi removido, False se não foi encontrado
-            
-        Raises:
-            RepositoryError: Se houver erro na remoção
-        """
+
+    async def delete(self, deck_id: uuid.UUID, owner_id: str) -> bool:
         try:
             collection = await self._get_collection()
-            
-            # Remove o deck
-            result = await collection.delete_one({"_id": uuid_to_object_id(deck_id)})
-            
+
+            result = await collection.delete_one({
+                "_id": uuid_to_object_id(deck_id),
+                "owner_id": owner_id,
+            })
+
             if result.deleted_count > 0:
-                # Remove todos os cards do deck
                 from apps.decks.infrastructure.repositories.card_repository import CardRepository
                 card_repository = CardRepository()
-                await card_repository.delete_by_deck_id(deck_id)
-                
-                # Remove todas as sessões de geração do deck
+                await card_repository.delete_by_deck_id(deck_id, owner_id)
+
                 from apps.decks.infrastructure.repositories.generation_session_repository import GenerationSessionRepository
                 session_repository = GenerationSessionRepository()
                 await session_repository.delete_by_deck_id(deck_id)
-                
+
                 return True
-            
+
             return False
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to delete deck: {e}")
-    
-    async def count(self) -> int:
-        """
-        Conta o total de decks no banco.
-        
-        Returns:
-            Número total de decks
-            
-        Raises:
-            RepositoryError: Se houver erro na contagem
-        """
+
+    async def count(self, owner_id: str) -> int:
         try:
             collection = await self._get_collection()
-            return await collection.count_documents({})
-            
+            return await collection.count_documents({"owner_id": owner_id})
+
         except Exception as e:
             raise RepositoryError(f"Failed to count decks: {e}")
-    
+
     async def count_by_user_id(self, user_id: str) -> int:
-        """
-        Conta o número de decks de um usuário.
-        
-        Args:
-            user_id: ID do usuário
-            
-        Returns:
-            Número de decks do usuário
-            
-        Raises:
-            RepositoryError: Se houver erro na contagem
-        """
         try:
             collection = await self._get_collection()
-            
-            # Por enquanto, retorna total de decks
-            # Em uma implementação futura, filtraria por user_id
-            return await collection.count_documents({})
-            
+            return await collection.count_documents({"owner_id": user_id})
+
         except Exception as e:
             raise RepositoryError(f"Failed to count decks by user ID: {e}")
-    
-    async def exists(self, deck_id: uuid.UUID) -> bool:
-        """
-        Verifica se um deck existe.
-        
-        Args:
-            deck_id: ID do deck
-            
-        Returns:
-            True se o deck existe, False caso contrário
-            
-        Raises:
-            RepositoryError: Se houver erro na verificação
-        """
+
+    async def exists(self, deck_id: uuid.UUID, owner_id: str) -> bool:
         try:
             collection = await self._get_collection()
-            count = await collection.count_documents({"_id": uuid_to_object_id(deck_id)})
+            count = await collection.count_documents({
+                "_id": uuid_to_object_id(deck_id),
+                "owner_id": owner_id,
+            })
             return count > 0
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to check if deck exists: {e}")
-    
-    async def exists_by_title(self, title: str, user_id: Optional[str] = None) -> bool:
-        """
-        Verifica se já existe um deck com o título especificado.
-        
-        Args:
-            title: Título para verificar
-            user_id: ID do usuário (opcional, para verificar apenas para um usuário)
-            
-        Returns:
-            True se já existe um deck com esse título
-            
-        Raises:
-            RepositoryError: Se houver erro na verificação
-        """
+
+    async def exists_by_title(self, title: str, owner_id: str) -> bool:
         try:
             collection = await self._get_collection()
-            
-            query = {"title": {"$regex": f"^{title}$", "$options": "i"}}
-            # Em uma implementação futura, adicionaríamos filtro por user_id
-            
+
+            query = {"title": {"$regex": f"^{title}$", "$options": "i"}, "owner_id": owner_id}
+
             count = await collection.count_documents(query)
             return count > 0
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to check if title exists: {e}")

--- a/django/apps/decks/infrastructure/repositories/generation_session_repository.py
+++ b/django/apps/decks/infrastructure/repositories/generation_session_repository.py
@@ -8,69 +8,62 @@ todas as operações definidas na interface.
 
 import uuid
 from typing import List, Optional
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from motor.motor_asyncio import AsyncIOMotorCollection
 from pymongo.errors import DuplicateKeyError, OperationFailure
 from bson import ObjectId
 
 from apps.decks.domain.entities.generation_session import GenerationSession, GenerationStatus
 from apps.decks.domain.repositories.igeneration_session_repository import IGenerationSessionRepository
+from apps.decks.infrastructure.exceptions import RepositoryError, SessionNotFoundError
 from apps.decks.infrastructure.mongodb_connection import ensure_mongodb_connection
 from apps.decks.infrastructure.schemas import GenerationSessionSchema, uuid_to_object_id
-from apps.decks.infrastructure.repositories.card_repository import RepositoryError
-
-
-class SessionNotFoundError(RepositoryError):
-    """
-    Exceção para quando uma sessão não é encontrada.
-    """
-    pass
 
 
 class GenerationSessionRepository(IGenerationSessionRepository):
     """
     Implementação MongoDB do GenerationSessionRepository.
-    
+
     Implementa todas as operações definidas na interface IGenerationSessionRepository
     usando MongoDB como banco de dados.
     """
-    
+
     def __init__(self):
         """
         Inicializa o repositório.
         """
         self._collection_name = "generation_sessions"
-        self._collection: Optional[AsyncIOMotorCollection] = None
-    
+
     async def _get_collection(self) -> AsyncIOMotorCollection:
         """
-        Retorna a collection MongoDB.
-        
+        Retorna a collection MongoDB. Nunca cacheia na instância — o
+        `AsyncIOMotorClient` fica preso ao event loop em que foi criado, e
+        esta instância pode ser reusada em chamadas separadas via
+        `async_to_sync`, cada uma com o seu próprio event loop novo (ver
+        Sprint 2, mongodb_connection.py `connect()`/`is_connected()`).
+
         Returns:
             Collection MongoDB
-            
+
         Raises:
             RepositoryError: Se não conseguir conectar
         """
-        if self._collection is None:
-            try:
-                mongodb_manager = await ensure_mongodb_connection()
-                self._collection = await mongodb_manager.get_collection(self._collection_name)
-            except Exception as e:
-                raise RepositoryError(f"Failed to get MongoDB collection: {e}")
-        
-        return self._collection
-    
+        try:
+            mongodb_manager = await ensure_mongodb_connection()
+            return await mongodb_manager.get_collection(self._collection_name)
+        except Exception as e:
+            raise RepositoryError(f"Failed to get MongoDB collection: {e}")
+
     async def save(self, session: GenerationSession) -> GenerationSession:
         """
         Salva uma sessão de geração no banco de dados.
-        
+
         Args:
             session: Sessão a ser salva
-            
+
         Returns:
             Sessão salva
-            
+
         Raises:
             RepositoryError: Se houver erro na persistência
         """
@@ -78,64 +71,66 @@ class GenerationSessionRepository(IGenerationSessionRepository):
             collection = await self._get_collection()
             session_data = session.to_dict()
             document = GenerationSessionSchema.to_document(session_data)
-            
+
             # Insere o documento
             result = await collection.insert_one(document)
-            
+
             # Atualiza o ID da sessão com o ObjectId gerado
             session.id = uuid.UUID(int=int(str(result.inserted_id), 16))
-            
+
             return session
-            
+
         except DuplicateKeyError as e:
             raise RepositoryError(f"Session with duplicate key: {e}")
         except Exception as e:
             raise RepositoryError(f"Failed to save session: {e}")
-    
-    async def find_by_id(self, session_id: uuid.UUID) -> Optional[GenerationSession]:
+
+    async def find_by_id(self, session_id: uuid.UUID, owner_id: str) -> Optional[GenerationSession]:
         """
         Busca uma sessão pelo ID.
-        
+
         Args:
             session_id: ID da sessão
-            
+            owner_id: dono dos cards do deck associado (ver docstring na
+                interface, IGenerationSessionRepository)
+
         Returns:
             Sessão se encontrada, None caso contrário
-            
+
         Raises:
             RepositoryError: Se houver erro na consulta
         """
         try:
             collection = await self._get_collection()
             document = await collection.find_one({"_id": uuid_to_object_id(session_id)})
-            
+
             if document is None:
                 return None
-            
+
             session_data = GenerationSessionSchema.from_document(document)
             session = GenerationSession.from_dict(session_data)
-            
+
             # Carrega os cards gerados da sessão
             from apps.decks.infrastructure.repositories.card_repository import CardRepository
             card_repository = CardRepository()
-            cards = await card_repository.find_by_deck_id(session.deck_id)
+            cards = await card_repository.find_by_deck_id(session.deck_id, owner_id)
             session.generated_cards = cards
-            
+
             return session
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to find session by ID: {e}")
-    
+
     async def find_by_deck_id(self, deck_id: uuid.UUID) -> List[GenerationSession]:
         """
         Busca todas as sessões de um deck.
-        
+
         Args:
             deck_id: ID do deck
-            
+
         Returns:
             Lista de sessões do deck
-            
+
         Raises:
             RepositoryError: Se houver erro na consulta
         """
@@ -143,28 +138,28 @@ class GenerationSessionRepository(IGenerationSessionRepository):
             collection = await self._get_collection()
             cursor = collection.find({"deck_id": uuid_to_object_id(deck_id)}).sort("created_at", -1)
             documents = await cursor.to_list(length=None)
-            
+
             sessions = []
             for document in documents:
                 session_data = GenerationSessionSchema.from_document(document)
                 session = GenerationSession.from_dict(session_data)
                 sessions.append(session)
-            
+
             return sessions
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to find sessions by deck ID: {e}")
-    
+
     async def find_by_status(self, status: GenerationStatus) -> List[GenerationSession]:
         """
         Busca sessões por status.
-        
+
         Args:
             status: Status das sessões
-            
+
         Returns:
             Lista de sessões com o status especificado
-            
+
         Raises:
             RepositoryError: Se houver erro na consulta
         """
@@ -172,28 +167,28 @@ class GenerationSessionRepository(IGenerationSessionRepository):
             collection = await self._get_collection()
             cursor = collection.find({"status": status.value}).sort("created_at", -1)
             documents = await cursor.to_list(length=None)
-            
+
             sessions = []
             for document in documents:
                 session_data = GenerationSessionSchema.from_document(document)
                 session = GenerationSession.from_dict(session_data)
                 sessions.append(session)
-            
+
             return sessions
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to find sessions by status: {e}")
-    
+
     async def find_by_context(self, context: str) -> List[GenerationSession]:
         """
         Busca sessões por contexto.
-        
+
         Args:
             context: Contexto para buscar
-            
+
         Returns:
             Lista de sessões que usam o contexto
-            
+
         Raises:
             RepositoryError: Se houver erro na consulta
         """
@@ -201,142 +196,142 @@ class GenerationSessionRepository(IGenerationSessionRepository):
             collection = await self._get_collection()
             cursor = collection.find({"context": context}).sort("created_at", -1)
             documents = await cursor.to_list(length=None)
-            
+
             sessions = []
             for document in documents:
                 session_data = GenerationSessionSchema.from_document(document)
                 session = GenerationSession.from_dict(session_data)
                 sessions.append(session)
-            
+
             return sessions
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to find sessions by context: {e}")
-    
+
     async def find_active_sessions(self, deck_id: Optional[uuid.UUID] = None) -> List[GenerationSession]:
         """
         Busca sessões ativas (não finalizadas).
-        
+
         Args:
             deck_id: ID do deck (opcional, para filtrar por deck)
-            
+
         Returns:
             Lista de sessões ativas
-            
+
         Raises:
             RepositoryError: Se houver erro na consulta
         """
         try:
             collection = await self._get_collection()
-            
+
             active_statuses = [
                 GenerationStatus.PENDING.value,
                 GenerationStatus.IN_PROGRESS.value
             ]
-            
+
             query = {"status": {"$in": active_statuses}}
             if deck_id:
                 query["deck_id"] = uuid_to_object_id(deck_id)
-            
+
             cursor = collection.find(query).sort("created_at", -1)
             documents = await cursor.to_list(length=None)
-            
+
             sessions = []
             for document in documents:
                 session_data = GenerationSessionSchema.from_document(document)
                 session = GenerationSession.from_dict(session_data)
                 sessions.append(session)
-            
+
             return sessions
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to find active sessions: {e}")
-    
+
     async def find_finished_sessions(self, deck_id: Optional[uuid.UUID] = None) -> List[GenerationSession]:
         """
         Busca sessões finalizadas (concluídas, falhadas ou canceladas).
-        
+
         Args:
             deck_id: ID do deck (opcional, para filtrar por deck)
-            
+
         Returns:
             Lista de sessões finalizadas
-            
+
         Raises:
             RepositoryError: Se houver erro na consulta
         """
         try:
             collection = await self._get_collection()
-            
+
             finished_statuses = [
                 GenerationStatus.COMPLETED.value,
                 GenerationStatus.FAILED.value,
                 GenerationStatus.CANCELLED.value
             ]
-            
+
             query = {"status": {"$in": finished_statuses}}
             if deck_id:
                 query["deck_id"] = uuid_to_object_id(deck_id)
-            
+
             cursor = collection.find(query).sort("created_at", -1)
             documents = await cursor.to_list(length=None)
-            
+
             sessions = []
             for document in documents:
                 session_data = GenerationSessionSchema.from_document(document)
                 session = GenerationSession.from_dict(session_data)
                 sessions.append(session)
-            
+
             return sessions
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to find finished sessions: {e}")
-    
+
     async def find_recent_sessions(self, limit: int = 10, deck_id: Optional[uuid.UUID] = None) -> List[GenerationSession]:
         """
         Busca as sessões mais recentes.
-        
+
         Args:
             limit: Número máximo de sessões a retornar
             deck_id: ID do deck (opcional, para filtrar por deck)
-            
+
         Returns:
             Lista de sessões ordenadas por data de criação (mais recentes primeiro)
-            
+
         Raises:
             RepositoryError: Se houver erro na consulta
         """
         try:
             collection = await self._get_collection()
-            
+
             query = {}
             if deck_id:
                 query["deck_id"] = uuid_to_object_id(deck_id)
-            
+
             cursor = collection.find(query).sort("created_at", -1).limit(limit)
             documents = await cursor.to_list(length=None)
-            
+
             sessions = []
             for document in documents:
                 session_data = GenerationSessionSchema.from_document(document)
                 session = GenerationSession.from_dict(session_data)
                 sessions.append(session)
-            
+
             return sessions
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to find recent sessions: {e}")
-    
+
     async def update(self, session: GenerationSession) -> GenerationSession:
         """
         Atualiza uma sessão existente.
-        
+
         Args:
             session: Sessão com dados atualizados
-            
+
         Returns:
             Sessão atualizada
-            
+
         Raises:
             RepositoryError: Se houver erro na atualização
             SessionNotFoundError: Se a sessão não existir
@@ -345,136 +340,136 @@ class GenerationSessionRepository(IGenerationSessionRepository):
             collection = await self._get_collection()
             session_data = session.to_dict()
             document = GenerationSessionSchema.to_document(session_data)
-            
+
             # Remove o _id do documento para atualização
             document.pop("_id", None)
-            
+
             result = await collection.replace_one(
                 {"_id": uuid_to_object_id(session.id)},
                 document
             )
-            
+
             if result.matched_count == 0:
                 raise SessionNotFoundError(f"Session with ID {session.id} not found")
-            
+
             return session
-            
+
         except SessionNotFoundError:
             raise
         except Exception as e:
             raise RepositoryError(f"Failed to update session: {e}")
-    
+
     async def delete(self, session_id: uuid.UUID) -> bool:
         """
         Remove uma sessão do banco de dados.
-        
+
         Args:
             session_id: ID da sessão a ser removida
-            
+
         Returns:
             True se a sessão foi removida, False se não foi encontrada
-            
+
         Raises:
             RepositoryError: Se houver erro na remoção
         """
         try:
             collection = await self._get_collection()
             result = await collection.delete_one({"_id": uuid_to_object_id(session_id)})
-            
+
             return result.deleted_count > 0
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to delete session: {e}")
-    
+
     async def delete_by_deck_id(self, deck_id: uuid.UUID) -> int:
         """
         Remove todas as sessões de um deck.
-        
+
         Args:
             deck_id: ID do deck
-            
+
         Returns:
             Número de sessões removidas
-            
+
         Raises:
             RepositoryError: Se houver erro na remoção
         """
         try:
             collection = await self._get_collection()
             result = await collection.delete_many({"deck_id": uuid_to_object_id(deck_id)})
-            
+
             return result.deleted_count
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to delete sessions by deck ID: {e}")
-    
+
     async def count(self) -> int:
         """
         Conta o total de sessões no banco.
-        
+
         Returns:
             Número total de sessões
-            
+
         Raises:
             RepositoryError: Se houver erro na contagem
         """
         try:
             collection = await self._get_collection()
             return await collection.count_documents({})
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to count sessions: {e}")
-    
+
     async def count_by_deck_id(self, deck_id: uuid.UUID) -> int:
         """
         Conta o número de sessões de um deck.
-        
+
         Args:
             deck_id: ID do deck
-            
+
         Returns:
             Número de sessões do deck
-            
+
         Raises:
             RepositoryError: Se houver erro na contagem
         """
         try:
             collection = await self._get_collection()
             return await collection.count_documents({"deck_id": uuid_to_object_id(deck_id)})
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to count sessions by deck ID: {e}")
-    
+
     async def count_by_status(self, status: GenerationStatus) -> int:
         """
         Conta o número de sessões com um status específico.
-        
+
         Args:
             status: Status das sessões
-            
+
         Returns:
             Número de sessões com o status
-            
+
         Raises:
             RepositoryError: Se houver erro na contagem
         """
         try:
             collection = await self._get_collection()
             return await collection.count_documents({"status": status.value})
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to count sessions by status: {e}")
-    
+
     async def exists(self, session_id: uuid.UUID) -> bool:
         """
         Verifica se uma sessão existe.
-        
+
         Args:
             session_id: ID da sessão
-            
+
         Returns:
             True se a sessão existe, False caso contrário
-            
+
         Raises:
             RepositoryError: Se houver erro na verificação
         """
@@ -482,29 +477,29 @@ class GenerationSessionRepository(IGenerationSessionRepository):
             collection = await self._get_collection()
             count = await collection.count_documents({"_id": uuid_to_object_id(session_id)})
             return count > 0
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to check if session exists: {e}")
-    
+
     async def cleanup_old_sessions(self, days_old: int = 30) -> int:
         """
         Remove sessões antigas (para limpeza de dados).
-        
+
         Args:
             days_old: Número de dias para considerar uma sessão como antiga
-            
+
         Returns:
             Número de sessões removidas
-            
+
         Raises:
             RepositoryError: Se houver erro na limpeza
         """
         try:
             collection = await self._get_collection()
-            
+
             # Calcula data limite
-            cutoff_date = datetime.utcnow() - timedelta(days=days_old)
-            
+            cutoff_date = datetime.now(timezone.utc) - timedelta(days=days_old)
+
             # Remove sessões antigas que estão finalizadas
             result = await collection.delete_many({
                 "created_at": {"$lt": cutoff_date},
@@ -516,8 +511,8 @@ class GenerationSessionRepository(IGenerationSessionRepository):
                     ]
                 }
             })
-            
+
             return result.deleted_count
-            
+
         except Exception as e:
             raise RepositoryError(f"Failed to cleanup old sessions: {e}")

--- a/django/apps/decks/infrastructure/schemas.py
+++ b/django/apps/decks/infrastructure/schemas.py
@@ -12,8 +12,27 @@ Collections definidas:
 """
 
 from typing import Dict, Any, Optional, List
-from datetime import datetime
+from datetime import datetime, timezone
 from bson import ObjectId
+
+
+def datetime_from_mongo(value: datetime) -> str:
+    """
+    Converte um datetime lido do MongoDB para string ISO, sempre com o
+    offset UTC explícito.
+
+    Pymongo/Motor devolvem datetimes *naive* na leitura (mesmo quando o
+    valor foi inserido como aware) — sem esse `replace`, o `.isoformat()`
+    resultante não carrega offset, e `datetime.fromisoformat()` do lado do
+    domínio reconstrói um datetime naive de novo. Isso já causou um bug
+    real: revisar o mesmo card uma segunda vez (com `last_reviewed_at`
+    vindo do Mongo) quebrava com "can't subtract offset-naive and
+    offset-aware datetimes" dentro do `fsrs.Scheduler`. Toda leitura de
+    datetime do Mongo passa por aqui.
+    """
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat()
 
 
 def uuid_to_object_id(value) -> ObjectId:
@@ -37,26 +56,26 @@ def uuid_to_object_id(value) -> ObjectId:
 class MongoDBSchema:
     """
     Classe base para schemas MongoDB.
-    
+
     Fornece métodos utilitários para conversão entre
     entidades de domínio e documentos MongoDB.
     """
-    
+
     @staticmethod
     def to_object_id(id_value: str) -> ObjectId:
         """
         Converte string ID para ObjectId MongoDB.
-        
+
         Args:
             id_value: ID como string
-            
+
         Returns:
             ObjectId MongoDB
         """
         if isinstance(id_value, ObjectId):
             return id_value
         return ObjectId(id_value)
-    
+
     @staticmethod
     def to_string_id(object_id: ObjectId) -> str:
         """
@@ -79,7 +98,7 @@ class MongoDBSchema:
 class CardSchema(MongoDBSchema):
     """
     Schema para collection 'cards'.
-    
+
     Estrutura do documento:
     {
         "_id": ObjectId,
@@ -109,15 +128,15 @@ class CardSchema(MongoDBSchema):
         "updated_at": datetime
     }
     """
-    
+
     @staticmethod
     def to_document(card_data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Converte dados de card para documento MongoDB.
-        
+
         Args:
             card_data: Dados do card (vindos de card.to_dict())
-            
+
         Returns:
             Documento MongoDB
         """
@@ -138,12 +157,23 @@ class CardSchema(MongoDBSchema):
                 "original_normalized": card_data["example"]["original_normalized"],
                 "translated_normalized": card_data["example"]["translated_normalized"]
             },
+            "owner_id": card_data["owner_id"],
             "context": card_data["context"],
             "deck_id": uuid_to_object_id(card_data["deck_id"]) if card_data["deck_id"] else None,
+            "tags": list(card_data.get("tags", [])),
+            "fsrs_state": card_data.get("fsrs_state", 1),
+            "fsrs_step": card_data.get("fsrs_step"),
+            "stability": card_data.get("stability"),
+            "difficulty": card_data.get("difficulty"),
+            "due_at": datetime.fromisoformat(card_data["due_at"]),
+            "last_reviewed_at": (
+                datetime.fromisoformat(card_data["last_reviewed_at"])
+                if card_data.get("last_reviewed_at") else None
+            ),
             "created_at": datetime.fromisoformat(card_data["created_at"]),
             "updated_at": datetime.fromisoformat(card_data["updated_at"])
         }
-        
+
         # Adiciona audio_path se existir
         if card_data.get("audio_path"):
             document["audio_path"] = {
@@ -151,17 +181,17 @@ class CardSchema(MongoDBSchema):
                 "filename": card_data["audio_path"]["filename"],
                 "exists": card_data["audio_path"]["exists"]
             }
-        
+
         return document
-    
+
     @staticmethod
     def from_document(document: Dict[str, Any]) -> Dict[str, Any]:
         """
         Converte documento MongoDB para dados de card.
-        
+
         Args:
             document: Documento MongoDB
-            
+
         Returns:
             Dados do card (para card.from_dict())
         """
@@ -191,12 +221,20 @@ class CardSchema(MongoDBSchema):
                 "length_original": len(document["example"]["original"]),
                 "length_translated": len(document["example"]["translated"])
             },
+            "owner_id": document["owner_id"],
             "context": document["context"],
             "deck_id": CardSchema.to_string_id(document["deck_id"]) if document["deck_id"] else None,
-            "created_at": document["created_at"].isoformat(),
-            "updated_at": document["updated_at"].isoformat()
+            "tags": list(document.get("tags", [])),
+            "fsrs_state": document.get("fsrs_state", 1),
+            "fsrs_step": document.get("fsrs_step"),
+            "stability": document.get("stability"),
+            "difficulty": document.get("difficulty"),
+            "due_at": datetime_from_mongo(document["due_at"]),
+            "last_reviewed_at": datetime_from_mongo(document["last_reviewed_at"]) if document.get("last_reviewed_at") else None,
+            "created_at": datetime_from_mongo(document["created_at"]),
+            "updated_at": datetime_from_mongo(document["updated_at"])
         }
-        
+
         # Adiciona audio_path se existir
         if document.get("audio_path"):
             card_data["audio_path"] = {
@@ -208,14 +246,14 @@ class CardSchema(MongoDBSchema):
                 "exists": document["audio_path"]["exists"],
                 "size_bytes": None  # Seria necessário verificar o arquivo
             }
-        
+
         return card_data
 
 
 class DeckSchema(MongoDBSchema):
     """
     Schema para collection 'decks'.
-    
+
     Estrutura do documento:
     {
         "_id": ObjectId,
@@ -228,57 +266,143 @@ class DeckSchema(MongoDBSchema):
         "is_empty": boolean
     }
     """
-    
+
     @staticmethod
     def to_document(deck_data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Converte dados de deck para documento MongoDB.
-        
+
         Args:
             deck_data: Dados do deck (vindos de deck.to_dict())
-            
+
         Returns:
             Documento MongoDB
         """
         return {
             "_id": ObjectId(),  # Gera um novo ObjectId
             "title": deck_data["title"],
+            "owner_id": deck_data["owner_id"],
             "description": deck_data["description"],
+            "category_id": uuid_to_object_id(deck_data["category_id"]) if deck_data.get("category_id") else None,
             "max_cards_per_generation": deck_data["max_cards_per_generation"],
             "created_at": datetime.fromisoformat(deck_data["created_at"]),
             "updated_at": datetime.fromisoformat(deck_data["updated_at"]),
             "card_count": deck_data["card_count"],
             "is_empty": deck_data["is_empty"]
         }
-    
+
     @staticmethod
     def from_document(document: Dict[str, Any]) -> Dict[str, Any]:
         """
         Converte documento MongoDB para dados de deck.
-        
+
         Args:
             document: Documento MongoDB
-            
+
         Returns:
             Dados do deck (para deck.from_dict())
         """
         return {
             "id": DeckSchema.to_string_id(document["_id"]),
             "title": document["title"],
+            "owner_id": document["owner_id"],
             "description": document["description"],
+            "category_id": DeckSchema.to_string_id(document["category_id"]) if document.get("category_id") else None,
             "cards": [],  # Cards são carregados separadamente
             "max_cards_per_generation": document["max_cards_per_generation"],
-            "created_at": document["created_at"].isoformat(),
-            "updated_at": document["updated_at"].isoformat(),
+            "created_at": datetime_from_mongo(document["created_at"]),
+            "updated_at": datetime_from_mongo(document["updated_at"]),
             "card_count": document["card_count"],
             "is_empty": document["is_empty"]
+        }
+
+
+class CategorySchema(MongoDBSchema):
+    """
+    Schema para collection 'categories'.
+
+    {
+        "_id": ObjectId,
+        "name": string,
+        "owner_id": string,
+        "created_at": datetime,
+        "updated_at": datetime
+    }
+    """
+
+    @staticmethod
+    def to_document(category_data: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "_id": ObjectId(),
+            "name": category_data["name"],
+            "owner_id": category_data["owner_id"],
+            "created_at": datetime.fromisoformat(category_data["created_at"]),
+            "updated_at": datetime.fromisoformat(category_data["updated_at"]),
+        }
+
+    @staticmethod
+    def from_document(document: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "id": CategorySchema.to_string_id(document["_id"]),
+            "name": document["name"],
+            "owner_id": document["owner_id"],
+            "created_at": datetime_from_mongo(document["created_at"]),
+            "updated_at": datetime_from_mongo(document["updated_at"]),
+        }
+
+
+class CardReviewSchema(MongoDBSchema):
+    """
+    Schema para collection 'card_reviews' — um documento por evento de
+    revisão (ver D5 em openspec/changes/sprint-2-decks-cards/design.md).
+
+    {
+        "_id": ObjectId,
+        "card_id": ObjectId,
+        "owner_id": string,
+        "rating": string,
+        "reviewed_at": datetime,
+        "stability_after": float | null,
+        "difficulty_after": float | null,
+        "due_at_after": datetime | null
+    }
+    """
+
+    @staticmethod
+    def to_document(review_data: Dict[str, Any]) -> Dict[str, Any]:
+        document = {
+            "_id": ObjectId(),
+            "card_id": uuid_to_object_id(review_data["card_id"]),
+            "owner_id": review_data["owner_id"],
+            "rating": review_data["rating"],
+            "reviewed_at": datetime.fromisoformat(review_data["reviewed_at"]),
+            "stability_after": review_data.get("stability_after"),
+            "difficulty_after": review_data.get("difficulty_after"),
+        }
+
+        if review_data.get("due_at_after"):
+            document["due_at_after"] = datetime.fromisoformat(review_data["due_at_after"])
+
+        return document
+
+    @staticmethod
+    def from_document(document: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "id": CardReviewSchema.to_string_id(document["_id"]),
+            "card_id": CardReviewSchema.to_string_id(document["card_id"]),
+            "owner_id": document["owner_id"],
+            "rating": document["rating"],
+            "reviewed_at": datetime_from_mongo(document["reviewed_at"]),
+            "stability_after": document.get("stability_after"),
+            "difficulty_after": document.get("difficulty_after"),
+            "due_at_after": datetime_from_mongo(document["due_at_after"]) if document.get("due_at_after") else None,
         }
 
 
 class GenerationSessionSchema(MongoDBSchema):
     """
     Schema para collection 'generation_sessions'.
-    
+
     Estrutura do documento:
     {
         "_id": ObjectId,
@@ -294,15 +418,15 @@ class GenerationSessionSchema(MongoDBSchema):
         "is_finished": boolean
     }
     """
-    
+
     @staticmethod
     def to_document(session_data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Converte dados de sessão para documento MongoDB.
-        
+
         Args:
             session_data: Dados da sessão (vindos de session.to_dict())
-            
+
         Returns:
             Documento MongoDB
         """
@@ -317,24 +441,24 @@ class GenerationSessionSchema(MongoDBSchema):
             "cards_generated_count": session_data["cards_generated_count"],
             "is_finished": session_data["is_finished"]
         }
-        
+
         # Adiciona campos opcionais
         if session_data.get("completed_at"):
             document["completed_at"] = datetime.fromisoformat(session_data["completed_at"])
-        
+
         if session_data.get("error_message"):
             document["error_message"] = session_data["error_message"]
-        
+
         return document
-    
+
     @staticmethod
     def from_document(document: Dict[str, Any]) -> Dict[str, Any]:
         """
         Converte documento MongoDB para dados de sessão.
-        
+
         Args:
             document: Documento MongoDB
-            
+
         Returns:
             Dados da sessão (para session.from_dict())
         """
@@ -345,19 +469,19 @@ class GenerationSessionSchema(MongoDBSchema):
             "status": document["status"],
             "generated_cards": [],  # Cards são carregados separadamente
             "max_cards": document["max_cards"],
-            "created_at": document["created_at"].isoformat(),
-            "updated_at": document["updated_at"].isoformat(),
+            "created_at": datetime_from_mongo(document["created_at"]),
+            "updated_at": datetime_from_mongo(document["updated_at"]),
             "cards_generated_count": document["cards_generated_count"],
             "is_finished": document["is_finished"]
         }
-        
+
         # Adiciona campos opcionais
         if document.get("completed_at"):
-            session_data["completed_at"] = document["completed_at"].isoformat()
-        
+            session_data["completed_at"] = datetime_from_mongo(document["completed_at"])
+
         if document.get("error_message"):
             session_data["error_message"] = document["error_message"]
-        
+
         return session_data
 
 
@@ -365,26 +489,47 @@ class IndexDefinitions:
     """
     Definições de índices para otimização das consultas MongoDB.
     """
-    
+
     # Índices para collection cards
     CARDS_INDEXES = [
+        ("owner_id", 1),
         ("deck_id", 1),
         ("word.normalized", 1),
         ("created_at", 1),
         ("updated_at", 1),
         ("context", 1),
+        ("due_at", 1),
+        ("tags", 1),
+        ([("owner_id", 1), ("deck_id", 1)], {}),
+        ([("owner_id", 1), ("due_at", 1)], {}),
         ([("deck_id", 1), ("word.normalized", 1)], {"unique": True}),
         ([("deck_id", 1), ("created_at", 1)], {}),
     ]
-    
+
     # Índices para collection decks
     DECKS_INDEXES = [
+        ("owner_id", 1),
         ("title", 1),
         ("created_at", 1),
         ("updated_at", 1),
         ("card_count", 1),
+        ([("owner_id", 1), ("category_id", 1)], {}),
     ]
-    
+
+    # Índices para collection categories
+    CATEGORIES_INDEXES = [
+        ("owner_id", 1),
+        ("name", 1),
+    ]
+
+    # Índices para collection card_reviews
+    CARD_REVIEWS_INDEXES = [
+        ("owner_id", 1),
+        ("card_id", 1),
+        ("reviewed_at", 1),
+        ([("owner_id", 1), ("card_id", 1)], {}),
+    ]
+
     # Índices para collection generation_sessions
     SESSIONS_INDEXES = [
         ("deck_id", 1),
@@ -395,17 +540,19 @@ class IndexDefinitions:
         ([("deck_id", 1), ("status", 1)], {}),
         ([("deck_id", 1), ("created_at", -1)], {}),
     ]
-    
+
     @staticmethod
     def get_all_indexes() -> Dict[str, List]:
         """
         Retorna todos os índices organizados por collection.
-        
+
         Returns:
             Dicionário com índices por collection
         """
         return {
             "cards": IndexDefinitions.CARDS_INDEXES,
             "decks": IndexDefinitions.DECKS_INDEXES,
+            "categories": IndexDefinitions.CATEGORIES_INDEXES,
+            "card_reviews": IndexDefinitions.CARD_REVIEWS_INDEXES,
             "generation_sessions": IndexDefinitions.SESSIONS_INDEXES
         }

--- a/django/apps/decks/management/commands/seed_decks.py
+++ b/django/apps/decks/management/commands/seed_decks.py
@@ -1,0 +1,212 @@
+"""
+Comando de seed multi-tenant para desenvolvimento local (PRD Sprint 2, 2.6).
+
+Roda como entrypoint async standalone (`asyncio.run`), fora do ciclo
+request/response do Django, usando `asyncio.gather` para inserções
+concorrentes reais — sem bridge `async_to_sync` (ver D3.1 em
+openspec/changes/sprint-2-decks-cards/design.md: este é exatamente o
+segundo consumidor que justifica manter os repositórios em Motor mesmo com
+as views do DRF sendo síncronas).
+
+Uso:
+    poetry run python manage.py seed_decks
+    poetry run python manage.py seed_decks --reset
+"""
+
+import asyncio
+import random
+from datetime import datetime, timedelta, timezone
+from typing import List
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.accounts.models import User
+from apps.decks.domain.entities.card import Card
+from apps.decks.domain.entities.card_review import CardReview
+from apps.decks.domain.entities.category import Category
+from apps.decks.domain.entities.deck import Deck
+from apps.decks.domain.services import scheduling_service
+from apps.decks.domain.value_objects.example import Example
+from apps.decks.domain.value_objects.translation import Translation
+from apps.decks.domain.value_objects.word import Word
+from apps.decks.infrastructure.mongodb_connection import ensure_mongodb_connection
+from apps.decks.infrastructure.repositories.card_repository import CardRepository
+from apps.decks.infrastructure.repositories.card_review_repository import CardReviewRepository
+from apps.decks.infrastructure.repositories.category_repository import CategoryRepository
+from apps.decks.infrastructure.repositories.deck_repository import DeckRepository
+
+SEED_USERNAMES = ["seed_ana", "seed_bruno", "seed_carla"]
+
+CATEGORY_NAMES = ["Programação", "Viagem"]
+
+DECKS_PER_CATEGORY = 2
+CARDS_PER_DECK = 4
+
+WORD_BANK = [
+    ("algorithm", "algoritmo"),
+    ("database", "banco de dados"),
+    ("keyboard", "teclado"),
+    ("network", "rede"),
+    ("function", "função"),
+    ("variable", "variável"),
+    ("compiler", "compilador"),
+    ("server", "servidor"),
+]
+
+RATINGS = ["again", "hard", "good", "easy"]
+
+# Passado distante, passado recente, e futuro — cobre a variedade de datas
+# exigida pelo PRD 2.6 / spec decks-seed-command.
+REVIEW_OFFSETS_DAYS = [-14, -3, 5]
+
+SEEDED_COLLECTIONS = ("cards", "decks", "categories", "card_reviews")
+
+
+class Command(BaseCommand):
+    help = "Popula o banco com dados de desenvolvimento multi-tenant (usuários/decks/categorias/cards/reviews)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--reset",
+            action="store_true",
+            help="Remove dados seedados anteriormente (dos usuários de seed) antes de recriar.",
+        )
+
+    def handle(self, *args, **options):
+        if not settings.DEBUG:
+            raise CommandError(
+                "seed_decks recusa rodar fora de DEBUG=True (proteção contra produção, ver PRD 2.6)."
+            )
+
+        asyncio.run(self._run(reset=options["reset"]))
+        self.stdout.write(self.style.SUCCESS("Seed concluído."))
+
+    async def _run(self, reset: bool) -> None:
+        await ensure_mongodb_connection()
+
+        users = await asyncio.to_thread(self._get_or_create_seed_users)
+
+        if reset:
+            await self._reset_seed_data(users)
+
+        await asyncio.gather(*[self._seed_for_user(user) for user in users])
+
+    def _get_or_create_seed_users(self) -> List[User]:
+        # Roda em uma thread separada via `asyncio.to_thread` (chamada de
+        # dentro de `_run`, async) — Django não fecha a conexão Postgres
+        # dessa thread sozinho quando ela termina, então fechamos
+        # explicitamente para não vazar conexão.
+        from django.db import connection
+
+        try:
+            users = []
+            for username in SEED_USERNAMES:
+                user, _ = User.objects.get_or_create(
+                    username=username,
+                    defaults={"email": f"{username}@seed.local"},
+                )
+                users.append(user)
+            return users
+        finally:
+            connection.close()
+
+    async def _reset_seed_data(self, users: List[User]) -> None:
+        mongodb_manager = await ensure_mongodb_connection()
+        owner_ids = [str(user.id) for user in users]
+
+        for collection_name in SEEDED_COLLECTIONS:
+            collection = await mongodb_manager.get_collection(collection_name)
+            await collection.delete_many({"owner_id": {"$in": owner_ids}})
+
+    async def _seed_for_user(self, user: User) -> None:
+        owner_id = str(user.id)
+
+        category_repo = CategoryRepository()
+        deck_repo = DeckRepository()
+        card_repo = CardRepository()
+        review_repo = CardReviewRepository()
+
+        categories = await self._create_categories(category_repo, owner_id)
+        decks = await self._create_decks(deck_repo, owner_id, categories)
+
+        await asyncio.gather(*[
+            self._seed_deck_cards(card_repo, review_repo, deck, owner_id)
+            for deck in decks
+        ])
+
+    async def _create_categories(self, category_repo: CategoryRepository, owner_id: str) -> List[Category]:
+        new_categories = [Category(name=name, owner_id=owner_id) for name in CATEGORY_NAMES]
+        save_calls = [category_repo.save(category) for category in new_categories]
+        return list(await asyncio.gather(*save_calls))
+
+    async def _create_decks(self, deck_repo: DeckRepository, owner_id: str, categories: List[Category]) -> List[Deck]:
+        new_decks = [
+            Deck(title=f"{category.name} — Deck {deck_number}", owner_id=owner_id, category_id=category.id)
+            for category in categories
+            for deck_number in range(1, DECKS_PER_CATEGORY + 1)
+        ]
+        save_calls = [deck_repo.save(deck) for deck in new_decks]
+        return list(await asyncio.gather(*save_calls))
+
+    async def _seed_deck_cards(
+        self,
+        card_repo: CardRepository,
+        review_repo: CardReviewRepository,
+        deck: Deck,
+        owner_id: str,
+    ) -> None:
+        deck_tag = deck.title.split(" ")[0].lower()
+        sampled_words = random.sample(WORD_BANK, k=CARDS_PER_DECK)
+        new_cards = [self._build_card(owner_id, deck.id, deck_tag, word, translation)
+                     for word, translation in sampled_words]
+
+        save_calls = [card_repo.save(card) for card in new_cards]
+        cards = await asyncio.gather(*save_calls)
+
+        await asyncio.gather(*[
+            self._seed_reviews_for_card(card_repo, review_repo, card, owner_id)
+            for card in cards
+        ])
+
+    def _build_card(self, owner_id: str, deck_id, tag: str, word: str, translation: str) -> Card:
+        return Card(
+            word=Word(word),
+            translation=Translation(translation),
+            example=Example(
+                original=f"This is an example sentence using {word}.",
+                translated=f"Esta é uma frase de exemplo usando {translation}.",
+            ),
+            owner_id=owner_id,
+            deck_id=deck_id,
+            tags=[tag],
+        )
+
+    async def _seed_reviews_for_card(
+        self,
+        card_repo: CardRepository,
+        review_repo: CardReviewRepository,
+        card: Card,
+        owner_id: str,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+
+        for days_offset in REVIEW_OFFSETS_DAYS:
+            reviewed_at = now + timedelta(days=days_offset)
+            rating = random.choice(RATINGS)
+
+            scheduling_service.review_card(card, rating, reviewed_at=reviewed_at)
+            await review_repo.save(self._build_review(card, owner_id, rating, reviewed_at))
+
+        await card_repo.update(card)
+
+    def _build_review(self, card: Card, owner_id: str, rating: str, reviewed_at: datetime) -> CardReview:
+        return CardReview(
+            card_id=card.id,
+            owner_id=owner_id,
+            rating=rating,
+            reviewed_at=reviewed_at,
+            stability_after=card.stability,
+            difficulty_after=card.difficulty,
+            due_at_after=card.due_at,
+        )

--- a/django/apps/decks/serializers.py
+++ b/django/apps/decks/serializers.py
@@ -1,0 +1,163 @@
+"""
+Serializers do domínio de decks/cards — todos `serializers.Serializer`
+puros, nunca `ModelSerializer` (que exige um Django Model real): o dado
+vive em MongoDB via repositórios Motor, não no ORM (ver D2 em
+openspec/changes/sprint-2-decks-cards/design.md). `create()`/`update()`
+delegam ao repositório correspondente, chamado via `async_to_sync` (D3).
+
+`owner_id` nunca é aceito como input do cliente — sempre vem de
+`self.context["request"].user`, no mesmo espírito do `AuditSerializerMixin`
+da Sprint 1 (apps/accounts/audit.py).
+"""
+
+from datetime import datetime, timezone
+
+from asgiref.sync import async_to_sync
+from rest_framework import serializers
+
+from .domain.entities.card import Card
+from .domain.entities.card_review import VALID_RATINGS
+from .domain.entities.category import Category
+from .domain.entities.deck import Deck
+from .domain.value_objects.example import Example
+from .domain.value_objects.translation import Translation
+from .domain.value_objects.word import Word
+from .infrastructure.repositories.card_repository import CardRepository
+from .infrastructure.repositories.category_repository import CategoryRepository
+from .infrastructure.repositories.deck_repository import DeckRepository
+
+
+class CategorySerializer(serializers.Serializer):
+    id = serializers.UUIDField(read_only=True)
+    name = serializers.CharField(max_length=200)
+    created_at = serializers.DateTimeField(read_only=True)
+    updated_at = serializers.DateTimeField(read_only=True)
+
+    def create(self, validated_data):
+        owner_id = str(self.context["request"].user.id)
+        category = Category(name=validated_data["name"], owner_id=owner_id)
+        return async_to_sync(CategoryRepository().save)(category)
+
+    def update(self, instance: Category, validated_data):
+        if "name" in validated_data:
+            instance.rename(validated_data["name"])
+        return async_to_sync(CategoryRepository().update)(instance)
+
+
+class DeckSerializer(serializers.Serializer):
+    id = serializers.UUIDField(read_only=True)
+    title = serializers.CharField(max_length=200)
+    description = serializers.CharField(allow_blank=True, required=False, default="")
+    category_id = serializers.UUIDField(required=False, allow_null=True)
+    max_cards_per_generation = serializers.IntegerField(required=False, default=10)
+    card_count = serializers.IntegerField(read_only=True)
+    is_empty = serializers.BooleanField(read_only=True)
+    created_at = serializers.DateTimeField(read_only=True)
+    updated_at = serializers.DateTimeField(read_only=True)
+
+    def create(self, validated_data):
+        owner_id = str(self.context["request"].user.id)
+        deck = Deck(
+            title=validated_data["title"],
+            owner_id=owner_id,
+            description=validated_data.get("description", ""),
+            category_id=validated_data.get("category_id"),
+            max_cards_per_generation=validated_data.get("max_cards_per_generation", 10),
+        )
+        return async_to_sync(DeckRepository().save)(deck)
+
+    def update(self, instance: Deck, validated_data):
+        if "title" in validated_data:
+            instance.update_title(validated_data["title"])
+        if "description" in validated_data:
+            instance.update_description(validated_data["description"])
+        if "category_id" in validated_data:
+            instance.category_id = validated_data["category_id"]
+            instance.updated_at = datetime.now(timezone.utc)
+        return async_to_sync(DeckRepository().update)(instance)
+
+
+class CardSerializer(serializers.Serializer):
+    """
+    `word`/`translation`/`example_original`/`example_translated` são campos
+    de entrada planos — o Card real guarda objetos de valor (`Word`,
+    `Translation`, `Example`), por isso a representação de saída é montada
+    manualmente em `to_representation`, em vez de depender do mapeamento
+    automático de atributo do DRF.
+    """
+
+    id = serializers.UUIDField(read_only=True)
+    word = serializers.CharField(max_length=200)
+    translation = serializers.CharField(max_length=200)
+    example_original = serializers.CharField()
+    example_translated = serializers.CharField()
+    context = serializers.CharField(allow_blank=True, required=False, default="")
+    deck_id = serializers.UUIDField()
+    tags = serializers.ListField(child=serializers.CharField(max_length=50), required=False, default=list)
+
+    def to_representation(self, instance: Card) -> dict:
+        return {
+            "id": str(instance.id),
+            "word": instance.word.value,
+            "translation": instance.translation.value,
+            "example_original": instance.example.original,
+            "example_translated": instance.example.translated,
+            "context": instance.context,
+            "deck_id": str(instance.deck_id) if instance.deck_id else None,
+            "tags": list(instance.tags),
+            "fsrs_state": instance.fsrs_state,
+            "stability": instance.stability,
+            "difficulty": instance.difficulty,
+            "due_at": instance.due_at.isoformat(),
+            "last_reviewed_at": instance.last_reviewed_at.isoformat() if instance.last_reviewed_at else None,
+            "created_at": instance.created_at.isoformat(),
+            "updated_at": instance.updated_at.isoformat(),
+        }
+
+    def create(self, validated_data):
+        owner_id = str(self.context["request"].user.id)
+        card = Card(
+            word=Word(validated_data["word"]),
+            translation=Translation(validated_data["translation"]),
+            example=Example(
+                original=validated_data["example_original"],
+                translated=validated_data["example_translated"],
+            ),
+            owner_id=owner_id,
+            context=validated_data.get("context", ""),
+            deck_id=validated_data["deck_id"],
+            tags=list(validated_data.get("tags", [])),
+        )
+        return async_to_sync(CardRepository().save)(card)
+
+    def update(self, instance: Card, validated_data):
+        if "word" in validated_data:
+            instance.word = Word(validated_data["word"])
+        if "translation" in validated_data:
+            new_translation = Translation(validated_data["translation"])
+            if new_translation != instance.translation:
+                instance.update_translation(new_translation)
+        if "example_original" in validated_data or "example_translated" in validated_data:
+            instance.update_example(Example(
+                original=validated_data.get("example_original", instance.example.original),
+                translated=validated_data.get("example_translated", instance.example.translated),
+            ))
+        if "context" in validated_data:
+            instance.context = validated_data["context"]
+        if "tags" in validated_data:
+            instance.tags = list(validated_data["tags"])
+        instance.updated_at = datetime.now(timezone.utc)
+        return async_to_sync(CardRepository().update)(instance)
+
+
+class CardReviewRequestSerializer(serializers.Serializer):
+    """Body de `POST /api/v1/cards/{id}/review/`."""
+
+    rating = serializers.ChoiceField(choices=sorted(VALID_RATINGS))
+
+
+class CardReviewSerializer(serializers.Serializer):
+    """Representação de saída de um `CardReview` já persistido."""
+
+    def to_representation(self, instance) -> dict:
+        return instance.to_dict()

--- a/django/apps/decks/tests/conftest.py
+++ b/django/apps/decks/tests/conftest.py
@@ -1,0 +1,81 @@
+"""
+Fixtures dos testes de decks/cards (Sprint 2). Requerem MongoDB real
+rodando (`docker compose up -d mongo`) — mesma convenção da Sprint 1
+(Postgres/Redis reais, nunca mockados).
+"""
+
+import asyncio
+
+# test_mongodb_integration.py é um script standalone (Sprint 0, funções
+# `async def` de nível de módulo, rodado via `python -m
+# apps.decks.tests.test_mongodb_integration`) — não uma suíte pytest. O
+# nome do arquivo/funções bate com o padrão de auto-descoberta do pytest
+# por coincidência; sem essa exclusão, pytest tenta coletá-lo e falha por
+# não ter suporte nativo a `async def` sem um plugin (não usamos
+# pytest-asyncio, ver PRD/convenção de testes em PROMPT_REFINADO.md).
+collect_ignore = ["test_mongodb_integration.py"]
+
+import pytest
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.accounts.models import User
+from apps.decks.infrastructure.mongodb_connection import ensure_mongodb_connection
+
+SEEDED_COLLECTIONS = ("cards", "decks", "categories", "card_reviews", "generation_sessions")
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+async def _clear_collections():
+    manager = await ensure_mongodb_connection()
+    for name in SEEDED_COLLECTIONS:
+        collection = await manager.get_collection(name)
+        await collection.delete_many({})
+
+
+@pytest.fixture(autouse=True)
+def _clean_mongo():
+    """Mongo não faz parte da transação de teste do Django — limpa manualmente."""
+    run_async(_clear_collections())
+    yield
+    run_async(_clear_collections())
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Evita que o throttle de um teste vaze pro próximo (cache Redis compartilhado)."""
+    from django.core.cache import cache
+
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def owner_a(db):
+    return User.objects.create_user(username="deck_owner_a", email="deck_owner_a@example.com")
+
+
+@pytest.fixture
+def owner_b(db):
+    return User.objects.create_user(username="deck_owner_b", email="deck_owner_b@example.com")
+
+
+def api_client_for(user: User) -> APIClient:
+    token = str(RefreshToken.for_user(user).access_token)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+    return client
+
+
+@pytest.fixture
+def client_a(owner_a) -> APIClient:
+    return api_client_for(owner_a)
+
+
+@pytest.fixture
+def client_b(owner_b) -> APIClient:
+    return api_client_for(owner_b)

--- a/django/apps/decks/tests/test_crud_api.py
+++ b/django/apps/decks/tests/test_crud_api.py
@@ -1,0 +1,107 @@
+"""
+CRUD dos endpoints de Deck/Category/Card (PRD Sprint 2, 2.1) via Generic
+Views do DRF sobre repositório Motor (D2/D3 em
+openspec/changes/sprint-2-decks-cards/design.md).
+
+Fluxos com mais de 3 requisições limpam o cache manualmente entre passos —
+o throttle de 3 req/s (Sprint 1) é por segundo, não por teste, e uma
+sequência de create/get/patch/delete real facilmente excede isso.
+"""
+
+import pytest
+from django.core.cache import cache
+
+
+@pytest.mark.django_db
+def test_deck_create_and_list(client_a):
+    response = client_a.post("/api/v1/decks/", {"title": "Meu Deck"}, format="json")
+    assert response.status_code == 201
+    assert response.data["title"] == "Meu Deck"
+    assert response.data["card_count"] == 0
+
+    response = client_a.get("/api/v1/decks/")
+    assert response.status_code == 200
+    assert response.data["count"] == 1
+
+
+@pytest.mark.django_db
+def test_deck_update_and_delete(client_a):
+    response = client_a.post("/api/v1/decks/", {"title": "Deck Original"}, format="json")
+    deck_id = response.data["id"]
+
+    cache.clear()
+    response = client_a.patch(f"/api/v1/decks/{deck_id}/", {"title": "Deck Renomeado"}, format="json")
+    assert response.status_code == 200
+    assert response.data["title"] == "Deck Renomeado"
+
+    cache.clear()
+    response = client_a.delete(f"/api/v1/decks/{deck_id}/")
+    assert response.status_code == 204
+
+    cache.clear()
+    response = client_a.get(f"/api/v1/decks/{deck_id}/")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_category_create_and_delete(client_a):
+    response = client_a.post("/api/v1/categories/", {"name": "Programação"}, format="json")
+    assert response.status_code == 201
+    category_id = response.data["id"]
+
+    cache.clear()
+    response = client_a.delete(f"/api/v1/categories/{category_id}/")
+    assert response.status_code == 204
+
+
+@pytest.mark.django_db
+def test_card_create_and_update(client_a):
+    response = client_a.post("/api/v1/decks/", {"title": "Deck de Cards"}, format="json")
+    deck_id = response.data["id"]
+
+    cache.clear()
+    response = client_a.post("/api/v1/cards/", {
+        "word": "server",
+        "translation": "servidor",
+        "example_original": "The server crashed twice today.",
+        "example_translated": "O servidor caiu duas vezes hoje.",
+        "deck_id": deck_id,
+    }, format="json")
+    assert response.status_code == 201
+    assert response.data["word"] == "server"
+    card_id = response.data["id"]
+
+    cache.clear()
+    response = client_a.patch(f"/api/v1/cards/{card_id}/", {"context": "infra"}, format="json")
+    assert response.status_code == 200
+    assert response.data["context"] == "infra"
+
+
+@pytest.mark.django_db
+def test_card_list_filtered_by_deck(client_a):
+    response = client_a.post("/api/v1/decks/", {"title": "Deck Filtro"}, format="json")
+    deck_id = response.data["id"]
+
+    cache.clear()
+    client_a.post("/api/v1/cards/", {
+        "word": "database",
+        "translation": "banco de dados",
+        "example_original": "The database needs a backup soon.",
+        "example_translated": "O banco de dados precisa de um backup em breve.",
+        "deck_id": deck_id,
+    }, format="json")
+
+    cache.clear()
+    response = client_a.get(f"/api/v1/cards/?deck_id={deck_id}")
+    assert response.status_code == 200
+    assert response.data["count"] == 1
+
+
+@pytest.mark.django_db
+def test_cross_tenant_deck_access_returns_404(client_a, client_b):
+    response = client_a.post("/api/v1/decks/", {"title": "Privado"}, format="json")
+    deck_id = response.data["id"]
+
+    cache.clear()
+    response = client_b.get(f"/api/v1/decks/{deck_id}/")
+    assert response.status_code == 404

--- a/django/apps/decks/tests/test_mongodb_integration.py
+++ b/django/apps/decks/tests/test_mongodb_integration.py
@@ -58,6 +58,9 @@ async def test_create_indexes(mongodb_manager):
         raise
 
 
+OWNER_ID = "integration-test-owner"
+
+
 async def test_deck_repository():
     """Testa operações do DeckRepository."""
     print("\n📚 Testando DeckRepository...")
@@ -67,6 +70,7 @@ async def test_deck_repository():
 
         deck = Deck(
             title="Deck de Teste",
+            owner_id=OWNER_ID,
             description="Deck criado para testes de integração",
             max_cards_per_generation=5,
         )
@@ -74,16 +78,16 @@ async def test_deck_repository():
         saved_deck = await deck_repo.save(deck)
         print(f"✅ Deck salvo: {saved_deck.id}")
 
-        found_deck = await deck_repo.find_by_id(saved_deck.id)
+        found_deck = await deck_repo.find_by_id(saved_deck.id, OWNER_ID)
         if found_deck:
             print(f"✅ Deck encontrado: {found_deck.title}")
         else:
             print("❌ Deck não encontrado")
 
-        decks_by_title = await deck_repo.find_by_title("Teste")
+        decks_by_title = await deck_repo.find_by_title("Teste", OWNER_ID)
         print(f"✅ Decks encontrados por título: {len(decks_by_title)}")
 
-        deck_count = await deck_repo.count()
+        deck_count = await deck_repo.count(OWNER_ID)
         print(f"✅ Total de decks: {deck_count}")
 
         return saved_deck
@@ -111,6 +115,7 @@ async def test_card_repository(deck):
             word=word,
             translation=translation,
             example=example,
+            owner_id=OWNER_ID,
             context="programming",
             deck_id=deck.id,
         )
@@ -118,22 +123,22 @@ async def test_card_repository(deck):
         saved_card = await card_repo.save(card)
         print(f"✅ Card salvo: {saved_card.id}")
 
-        found_card = await card_repo.find_by_id(saved_card.id)
+        found_card = await card_repo.find_by_id(saved_card.id, OWNER_ID)
         if found_card:
             print(f"✅ Card encontrado: {found_card.word.value}")
         else:
             print("❌ Card não encontrado")
 
-        cards_by_word = await card_repo.find_by_word("algorithm")
+        cards_by_word = await card_repo.find_by_word("algorithm", OWNER_ID)
         print(f"✅ Cards encontrados por palavra: {len(cards_by_word)}")
 
-        cards_by_deck = await card_repo.find_by_deck_id(deck.id)
+        cards_by_deck = await card_repo.find_by_deck_id(deck.id, OWNER_ID)
         print(f"✅ Cards encontrados no deck: {len(cards_by_deck)}")
 
-        word_exists = await card_repo.exists_by_word("algorithm", deck.id)
+        word_exists = await card_repo.exists_by_word("algorithm", OWNER_ID, deck.id)
         print(f"✅ Palavra existe no deck: {word_exists}")
 
-        card_count = await card_repo.count()
+        card_count = await card_repo.count(OWNER_ID)
         print(f"✅ Total de cards: {card_count}")
 
         return saved_card
@@ -159,7 +164,7 @@ async def test_generation_session_repository(deck):
         saved_session = await session_repo.save(session)
         print(f"✅ Sessão salva: {saved_session.id}")
 
-        found_session = await session_repo.find_by_id(saved_session.id)
+        found_session = await session_repo.find_by_id(saved_session.id, OWNER_ID)
         if found_session:
             print(f"✅ Sessão encontrada: {found_session.status.value}")
         else:

--- a/django/apps/decks/tests/test_multi_tenant_isolation.py
+++ b/django/apps/decks/tests/test_multi_tenant_isolation.py
@@ -1,0 +1,80 @@
+"""
+`<ponto_critico id="isolamento-multi-tenant">`: mesmo padrão de rigor da
+Sprint 1, mas testado na camada onde ele realmente mora para decks/cards —
+os repositórios Mongo (ver D1 em
+openspec/changes/sprint-2-decks-cards/design.md), não um mixin de
+QuerySet do Django ORM.
+"""
+
+import pytest
+
+from apps.decks.domain.entities.card import Card
+from apps.decks.domain.entities.card_review import CardReview
+from apps.decks.domain.entities.category import Category
+from apps.decks.domain.entities.deck import Deck
+from apps.decks.domain.value_objects.example import Example
+from apps.decks.domain.value_objects.translation import Translation
+from apps.decks.domain.value_objects.word import Word
+from apps.decks.infrastructure.repositories.card_repository import CardRepository
+from apps.decks.infrastructure.repositories.card_review_repository import CardReviewRepository
+from apps.decks.infrastructure.repositories.category_repository import CategoryRepository
+from apps.decks.infrastructure.repositories.deck_repository import DeckRepository
+
+from .conftest import run_async
+
+
+def _build_card(owner_id, deck_id) -> Card:
+    return Card(
+        word=Word("network"),
+        translation=Translation("rede"),
+        example=Example(original="The network is down today.", translated="A rede esta fora do ar hoje."),
+        owner_id=owner_id,
+        deck_id=deck_id,
+    )
+
+
+@pytest.mark.django_db
+def test_deck_cross_tenant_access_is_blocked(owner_a, owner_b):
+    owner_id_a, owner_id_b = str(owner_a.id), str(owner_b.id)
+
+    deck = run_async(DeckRepository().save(Deck(title="Secreto", owner_id=owner_id_a)))
+
+    assert run_async(DeckRepository().find_by_id(deck.id, owner_id_a)) is not None
+    assert run_async(DeckRepository().find_by_id(deck.id, owner_id_b)) is None
+
+
+@pytest.mark.django_db
+def test_category_cross_tenant_access_is_blocked(owner_a, owner_b):
+    owner_id_a, owner_id_b = str(owner_a.id), str(owner_b.id)
+
+    category = run_async(CategoryRepository().save(Category(name="Trabalho", owner_id=owner_id_a)))
+
+    assert run_async(CategoryRepository().find_by_id(category.id, owner_id_a)) is not None
+    assert run_async(CategoryRepository().find_by_id(category.id, owner_id_b)) is None
+
+
+@pytest.mark.django_db
+def test_card_cross_tenant_access_is_blocked(owner_a, owner_b):
+    owner_id_a, owner_id_b = str(owner_a.id), str(owner_b.id)
+
+    deck = run_async(DeckRepository().save(Deck(title="Deck A", owner_id=owner_id_a)))
+    card = run_async(CardRepository().save(_build_card(owner_id_a, deck.id)))
+
+    assert run_async(CardRepository().find_by_id(card.id, owner_id_a)) is not None
+    assert run_async(CardRepository().find_by_id(card.id, owner_id_b)) is None
+    assert run_async(CardRepository().find_by_deck_id(deck.id, owner_id_b)) == []
+
+
+@pytest.mark.django_db
+def test_card_review_cross_tenant_access_is_blocked(owner_a, owner_b):
+    owner_id_a, owner_id_b = str(owner_a.id), str(owner_b.id)
+
+    deck = run_async(DeckRepository().save(Deck(title="Deck A", owner_id=owner_id_a)))
+    card = run_async(CardRepository().save(_build_card(owner_id_a, deck.id)))
+    run_async(CardReviewRepository().save(CardReview(card_id=card.id, owner_id=owner_id_a, rating="good")))
+
+    own_reviews = run_async(CardReviewRepository().find_by_card_id(card.id, owner_id_a))
+    other_reviews = run_async(CardReviewRepository().find_by_card_id(card.id, owner_id_b))
+
+    assert len(own_reviews) == 1
+    assert other_reviews == []

--- a/django/apps/decks/tests/test_review_scheduling.py
+++ b/django/apps/decks/tests/test_review_scheduling.py
@@ -1,0 +1,95 @@
+"""
+Registro de revisão (PRD Sprint 2, 2.2/2.3) — dispara o agendamento FSRS
+(domain/services/scheduling_service.py) e grava um `CardReview` (D4/D5 em
+openspec/changes/sprint-2-decks-cards/design.md), além da consulta de
+cards devidos.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from apps.decks.domain.entities.card import Card
+from apps.decks.domain.entities.deck import Deck
+from apps.decks.domain.value_objects.example import Example
+from apps.decks.domain.value_objects.translation import Translation
+from apps.decks.domain.value_objects.word import Word
+from apps.decks.infrastructure.repositories.card_repository import CardRepository
+from apps.decks.infrastructure.repositories.deck_repository import DeckRepository
+
+from .conftest import run_async
+
+
+def _build_card(owner_id, deck_id, word="cache") -> Card:
+    return Card(
+        word=Word(word),
+        translation=Translation("traducao"),
+        example=Example(original="This is an example sentence here.", translated="Esta eh uma frase de exemplo aqui."),
+        owner_id=owner_id,
+        deck_id=deck_id,
+    )
+
+
+@pytest.mark.django_db
+def test_review_action_updates_schedule_and_creates_review(client_a, owner_a):
+    owner_id = str(owner_a.id)
+    deck = run_async(DeckRepository().save(Deck(title="Deck Review", owner_id=owner_id)))
+    card = run_async(CardRepository().save(_build_card(owner_id, deck.id)))
+
+    assert card.stability is None
+
+    response = client_a.post(f"/api/v1/cards/{card.id}/review/", {"rating": "good"}, format="json")
+
+    assert response.status_code == 201
+    assert response.data["rating"] == "good"
+    assert response.data["card_id"] == str(card.id)
+    assert response.data["stability_after"] is not None
+
+    updated_card = run_async(CardRepository().find_by_id(card.id, owner_id))
+    assert updated_card.stability == response.data["stability_after"]
+    assert updated_card.last_reviewed_at is not None
+
+
+@pytest.mark.django_db
+def test_review_rejects_invalid_rating(client_a, owner_a):
+    owner_id = str(owner_a.id)
+    deck = run_async(DeckRepository().save(Deck(title="Deck Review 2", owner_id=owner_id)))
+    card = run_async(CardRepository().save(_build_card(owner_id, deck.id, word="token")))
+
+    response = client_a.post(f"/api/v1/cards/{card.id}/review/", {"rating": "excellent"}, format="json")
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_review_on_other_owner_card_returns_404(client_a, client_b, owner_b):
+    owner_id_b = str(owner_b.id)
+    deck = run_async(DeckRepository().save(Deck(title="Deck B", owner_id=owner_id_b)))
+    card = run_async(CardRepository().save(_build_card(owner_id_b, deck.id, word="secret")))
+
+    response = client_a.post(f"/api/v1/cards/{card.id}/review/", {"rating": "good"}, format="json")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_due_cards_only_returns_owned_and_due(owner_a, owner_b):
+    owner_id_a, owner_id_b = str(owner_a.id), str(owner_b.id)
+    deck_a = run_async(DeckRepository().save(Deck(title="Deck A", owner_id=owner_id_a)))
+    deck_b = run_async(DeckRepository().save(Deck(title="Deck B", owner_id=owner_id_b)))
+
+    due_card = _build_card(owner_id_a, deck_a.id, word="duecard")
+    due_card.due_at = datetime.now(timezone.utc) - timedelta(days=1)
+    due_card = run_async(CardRepository().save(due_card))
+
+    future_card = _build_card(owner_id_a, deck_a.id, word="futurecard")
+    future_card.due_at = datetime.now(timezone.utc) + timedelta(days=10)
+    future_card = run_async(CardRepository().save(future_card))
+
+    other_owner_due_card = _build_card(owner_id_b, deck_b.id, word="otherowner")
+    other_owner_due_card.due_at = datetime.now(timezone.utc) - timedelta(days=1)
+    other_owner_due_card = run_async(CardRepository().save(other_owner_due_card))
+
+    due_ids = {str(c.id) for c in run_async(CardRepository().find_due(owner_id_a))}
+
+    assert str(due_card.id) in due_ids
+    assert str(future_card.id) not in due_ids
+    assert str(other_owner_due_card.id) not in due_ids

--- a/django/apps/decks/tests/test_seed_command.py
+++ b/django/apps/decks/tests/test_seed_command.py
@@ -1,0 +1,49 @@
+"""
+Comando de seed (PRD Sprint 2, 2.6/2.7): guarda contra produção e
+`--reset` não duplicando dados.
+
+`pytest-django` força `DEBUG=False` para todos os testes por padrão
+(comportamento documentado do plugin, independente do que
+`core.settings.local` define) — então o teste da guarda de produção já
+exercita o caso real por padrão, e o teste do seed bem-sucedido precisa
+reverter isso explicitamente com `override_settings(DEBUG=True)`.
+"""
+
+import pytest
+from django.core.management import CommandError, call_command
+from django.test import override_settings
+
+from apps.decks.infrastructure.mongodb_connection import ensure_mongodb_connection
+
+from .conftest import run_async
+
+
+async def _count_documents(collection_name: str) -> int:
+    manager = await ensure_mongodb_connection()
+    collection = await manager.get_collection(collection_name)
+    return await collection.count_documents({})
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=False)
+def test_seed_command_refuses_outside_debug():
+    with pytest.raises(CommandError):
+        call_command("seed_decks")
+
+    assert run_async(_count_documents("decks")) == 0
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_seed_command_reset_does_not_duplicate():
+    call_command("seed_decks")
+    first_deck_count = run_async(_count_documents("decks"))
+    first_card_count = run_async(_count_documents("cards"))
+
+    assert first_deck_count > 0
+    assert first_card_count > 0
+
+    call_command("seed_decks", "--reset")
+
+    assert run_async(_count_documents("decks")) == first_deck_count
+    assert run_async(_count_documents("cards")) == first_card_count

--- a/django/apps/decks/urls.py
+++ b/django/apps/decks/urls.py
@@ -1,0 +1,21 @@
+"""
+URLs do domínio de decks/cards. Versionamento (`/api/v1/`) é aplicado uma
+única vez em `core/urls.py`, no `include()` deste módulo — mesmo padrão do
+`API_PREFIX` usado nos microsserviços FastAPI (ver
+`<regra_obrigatoria id="versionamento-url-microservicos">` em
+PROMPT_REFINADO.md).
+"""
+
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path("categories/", views.CategoryListCreateView.as_view(), name="category-list"),
+    path("categories/<str:category_id>/", views.CategoryDetailView.as_view(), name="category-detail"),
+    path("decks/", views.DeckListCreateView.as_view(), name="deck-list"),
+    path("decks/<str:deck_id>/", views.DeckDetailView.as_view(), name="deck-detail"),
+    path("cards/", views.CardListCreateView.as_view(), name="card-list"),
+    path("cards/<str:card_id>/", views.CardDetailView.as_view(), name="card-detail"),
+    path("cards/<str:card_id>/review/", views.CardReviewView.as_view(), name="card-review"),
+]

--- a/django/apps/decks/views.py
+++ b/django/apps/decks/views.py
@@ -1,0 +1,142 @@
+"""
+Views REST de decks/cards (Sprint 2). Generic Views do DRF sobre
+repositórios Motor: serializers puros, `get_queryset()` devolve uma lista
+Python já resolvida via `async_to_sync`, nunca um `QuerySet` real (D2/D3 em
+openspec/changes/sprint-2-decks-cards/design.md). `APIView` pontual para a
+ação de registrar revisão, que não é uma substituição de estado CRUD.
+"""
+
+import uuid
+
+from asgiref.sync import async_to_sync
+from rest_framework import generics, status
+from rest_framework.exceptions import NotFound
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .domain.entities.card_review import CardReview
+from .domain.services import scheduling_service
+from .infrastructure.repositories.card_repository import CardRepository
+from .infrastructure.repositories.card_review_repository import CardReviewRepository
+from .infrastructure.repositories.category_repository import CategoryRepository
+from .infrastructure.repositories.deck_repository import DeckRepository
+from .serializers import (
+    CardReviewRequestSerializer,
+    CardReviewSerializer,
+    CardSerializer,
+    CategorySerializer,
+    DeckSerializer,
+)
+
+
+def _owner_id(request) -> str:
+    return str(request.user.id)
+
+
+class CategoryListCreateView(generics.ListCreateAPIView):
+    serializer_class = CategorySerializer
+
+    def get_queryset(self):
+        return async_to_sync(CategoryRepository().find_all)(_owner_id(self.request))
+
+
+class CategoryDetailView(generics.RetrieveUpdateDestroyAPIView):
+    serializer_class = CategorySerializer
+
+    def get_object(self):
+        category_id = uuid.UUID(self.kwargs["category_id"])
+        category = async_to_sync(CategoryRepository().find_by_id)(category_id, _owner_id(self.request))
+        if category is None:
+            raise NotFound()
+        return category
+
+    def perform_destroy(self, instance):
+        async_to_sync(CategoryRepository().delete)(instance.id, _owner_id(self.request))
+
+
+class DeckListCreateView(generics.ListCreateAPIView):
+    serializer_class = DeckSerializer
+
+    def get_queryset(self):
+        return async_to_sync(DeckRepository().find_all)(_owner_id(self.request))
+
+
+class DeckDetailView(generics.RetrieveUpdateDestroyAPIView):
+    serializer_class = DeckSerializer
+
+    def get_object(self):
+        deck_id = uuid.UUID(self.kwargs["deck_id"])
+        deck = async_to_sync(DeckRepository().find_by_id)(deck_id, _owner_id(self.request))
+        if deck is None:
+            raise NotFound()
+        return deck
+
+    def perform_destroy(self, instance):
+        async_to_sync(DeckRepository().delete)(instance.id, _owner_id(self.request))
+
+
+class CardListCreateView(generics.ListCreateAPIView):
+    serializer_class = CardSerializer
+
+    def get_queryset(self):
+        owner_id = _owner_id(self.request)
+        card_repo = CardRepository()
+
+        if self.request.query_params.get("due") == "true":
+            return async_to_sync(card_repo.find_due)(owner_id)
+
+        deck_id = self.request.query_params.get("deck_id")
+        if not deck_id:
+            return []
+
+        return async_to_sync(card_repo.find_by_deck_id)(uuid.UUID(deck_id), owner_id)
+
+
+class CardDetailView(generics.RetrieveUpdateDestroyAPIView):
+    serializer_class = CardSerializer
+
+    def get_object(self):
+        card_id = uuid.UUID(self.kwargs["card_id"])
+        card = async_to_sync(CardRepository().find_by_id)(card_id, _owner_id(self.request))
+        if card is None:
+            raise NotFound()
+        return card
+
+    def perform_destroy(self, instance):
+        async_to_sync(CardRepository().delete)(instance.id, _owner_id(self.request))
+
+
+class CardReviewView(APIView):
+    """
+    `POST /api/v1/cards/{card_id}/review/` — dispara o agendamento FSRS
+    (domain/services/scheduling_service.py) e grava o evento em
+    `CardReview` (D4/D5 em design.md). Ação de domínio, não CRUD, por isso
+    `APIView` em vez de um Generic View (D2).
+    """
+
+    def post(self, request, card_id):
+        owner_id = _owner_id(request)
+        card_repo = CardRepository()
+
+        card = async_to_sync(card_repo.find_by_id)(uuid.UUID(card_id), owner_id)
+        if card is None:
+            raise NotFound()
+
+        request_serializer = CardReviewRequestSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+        rating = request_serializer.validated_data["rating"]
+
+        scheduling_service.review_card(card, rating)
+        async_to_sync(card_repo.update)(card)
+
+        review = CardReview(
+            card_id=card.id,
+            owner_id=owner_id,
+            rating=rating,
+            stability_after=card.stability,
+            difficulty_after=card.difficulty,
+            due_at_after=card.due_at,
+        )
+        async_to_sync(CardReviewRepository().save)(review)
+
+        return Response(CardReviewSerializer(review).data, status=status.HTTP_201_CREATED)

--- a/django/core/exceptions.py
+++ b/django/core/exceptions.py
@@ -1,0 +1,40 @@
+"""
+Exceção base do projeto. Toda exceção customizada (de qualquer app) DEVE
+herdar de `AppError`, direta ou indiretamente, em vez de levantar
+`ValueError`/`RuntimeError`/`Exception` puros.
+
+Isso não é só estilo: qualquer camada que precise reagir a "um erro
+nosso" (um exception handler do DRF, um log estruturado, um teste) pode
+fazer `except AppError` uma vez só, em vez de manter uma lista de tipos
+soltos espalhada pelo projeto.
+
+`AppError` é abstrata — Python levanta `TypeError` se alguém tentar
+instanciá-la diretamente, porque toda subclasse concreta é obrigada a
+implementar `code`: um identificador curto e estável (ex.:
+`"card_not_found"`), pensado para ser consumido por quem lida com o erro
+sem precisar de uma cadeia de `isinstance`.
+
+Este módulo não importa nada do Django de propósito — é puro Python
+(`abc` + `Exception`), então tanto a camada de domínio (que não deve
+depender de nada externo) quanto a de infraestrutura podem herdar dele
+sem ganhar uma dependência real do framework.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class AppError(Exception, ABC):
+    def __init__(self, *args, **kwargs):
+        # `ABC` sozinho não bloqueia instanciação aqui: `BaseException.__new__`
+        # é implementado em C e não passa pela checagem de `__abstractmethods__`
+        # que `object.__new__` faz normalmente — é um gotcha conhecido de
+        # combinar `Exception` com `ABC`. Sem este guard manual,
+        # `AppError("x")` seria instanciável mesmo com `code` abstrato.
+        if type(self) is AppError:
+            raise TypeError("AppError é abstrata — levante uma subclasse concreta.")
+        super().__init__(*args, **kwargs)
+
+    @property
+    @abstractmethod
+    def code(self) -> str:
+        raise NotImplementedError

--- a/django/core/settings/base.py
+++ b/django/core/settings/base.py
@@ -138,6 +138,12 @@ REST_FRAMEWORK = {
         "user": "3/second",
         "anon": "3/second",
     },
+    # Generic Views sobre decks/cards (Mongo) devolvem uma lista Python já
+    # resolvida em `get_queryset()`, não um QuerySet — PageNumberPagination
+    # só precisa de algo fatiável/contável, então funciona igual (ver D2 em
+    # openspec/changes/sprint-2-decks-cards/design.md).
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 20,
 }
 
 # Access token curto + refresh token mais longo, com rotação a cada uso —

--- a/django/core/urls.py
+++ b/django/core/urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/v1/health/", HealthCheckView.as_view(), name="health"),
     path("api/v1/auth/", include("apps.accounts.urls")),
+    path("api/v1/", include("apps.decks.urls")),
 ]

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -20,6 +20,7 @@ django-allauth = "^65.18.0"
 dj-rest-auth = "^7.2.0"
 requests = "^2.34.2"
 cryptography = "^50.0.0"
+fsrs = "^6.3.2"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Isolamento multi-tenant em MongoDB (owner_id obrigatorio em todo metodo de repositorio), repeticao espacada via FSRS, entidades Category/CardReview novas, endpoints REST versionados (Generic Views + APIView pontual) e comando de seed multi-tenant.

Dois bugs reais de producao encontrados e corrigidos via verificacao end-to-end (nao so testes unitarios): AsyncIOMotorClient preso a um event loop fechado apos a segunda chamada bridged via async_to_sync; e datetimes naive na volta do Mongo quebrando a segunda revisao do mesmo card (datetime.utcnow() trocado por datetime.now(timezone.utc) em todo o app).

Hierarquia de excecoes propria (core/exceptions.py: AppError abstrata, DomainValidationError, InfrastructureError e subtipos) substitui os ValueError/RuntimeError crus da camada de dominio e infraestrutura.

28/28 testes passando (12 Sprint 1 + 16 novos).